### PR TITLE
GitHub action fixappimage

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -18,6 +18,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${CI_REF_NAME}_${CI_SHA_SHORT}
+      shell: bash
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
@@ -39,8 +43,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-        releaseName: "App v__VERSION__"
+        tagName: app-v${steps.get_version.outputs.VERSION}
+        releaseName: "App v${steps.get_version.outputs.VERSION}"
         body: "See the assets to download this version and install."
         draft: true
         prerelease: false

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -22,6 +22,8 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
     - name: install tauri bundler
       run: cargo install tauri-bundler --force
     - name: install webkit2gtk (ubuntu only)

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Fixes to:

* Publish ubuntu appImage using derivative tauri action published by other contributor
* Use cargo cache to hopefully speed up builds
* Use github variable to caption versions for deployment based on commit slug and tag. Might want to pick a better var from here: https://github.com/marketplace/actions/github-environment-variables-action