### PR TITLE
Fix phone and zip patterns, and labeled input regression

### DIFF
--- a/src/components/Patterns.ts
+++ b/src/components/Patterns.ts
@@ -59,11 +59,11 @@ const text = (regexp: RegExp, description: string): TextPattern => ({
 
 export const Patterns = {
   name: text(/^[A-Za-z ]+$/i, 'Input should only include letters and spaces'),
-  zip: numeric(/[0-9]{9}/, 'Input should be filled with 9 digits', '#####-####'),
+  zip: numeric(/[0-9]{5}([0-9]{4})?/, 'Input should be filled with 5 or 9 digits', '#####-####'),
   ssn: numeric(/[0-9]{9}/, 'Input should be filled with 9 digits', '###-##-####'),
   ein: numeric(/[0-9]{9}/, 'Input should be filled with 9 digits', '##-#######'),
   currency: numeric(/[1-9][0-9]+(\.[0-9]{1,2})?/, 'Input should be a numeric value', undefined, '_', true, '$', 2),
   bankAccount: numeric(/[0-9]{4,17}/, 'Input should be filled with 4-17 digits', '#################', ''),
   bankRouting: numeric(/[0-9]{9}/, 'Input should be filled with 9 digits', '#########', '_'),
-  usPhoneNumber: numeric(/[0-9]{10}/, 'Input should be filled with 10 digits', '(###)-###-####')
+  usPhoneNumber: numeric(/[2-9][0-9]{9}/, 'Input should be 10 digits, not starting with 0 or 1', '(###)-###-####')
 }

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -2,11 +2,11 @@ import React, { ReactElement } from 'react'
 import { TextField, Box } from '@material-ui/core'
 import { LabeledInputProps } from './types'
 import NumberFormat from 'react-number-format'
-import { InputType, Patterns } from '../Patterns'
+import { InputType } from '../Patterns'
 import { Controller } from 'react-hook-form'
 
 export function LabeledInput (props: LabeledInputProps): ReactElement {
-  const { strongLabel, label, register, error, required = false, patternConfig = Patterns.name, name, defaultValue } = props
+  const { strongLabel, label, register, error, required = false, patternConfig, name, defaultValue } = props
 
   const baseFieldProps = {
     fullWidth: patternConfig?.format === undefined,
@@ -16,7 +16,7 @@ export function LabeledInput (props: LabeledInputProps): ReactElement {
   }
 
   const input: ReactElement = (() => {
-    if (patternConfig.inputType === InputType.numeric) {
+    if (patternConfig?.inputType === InputType.numeric) {
       return (
         <Controller
           render={({ onChange, value }) =>
@@ -58,8 +58,8 @@ export function LabeledInput (props: LabeledInputProps): ReactElement {
         inputRef={register({
           required: required ? 'Input is required' : undefined,
           pattern: {
-            value: patternConfig.regexp ?? (required ? /.+/ : /.*/),
-            message: patternConfig.description ?? (required ? 'Input is required' : '')
+            value: patternConfig?.regexp ?? (required ? /.+/ : /.*/),
+            message: patternConfig?.description ?? (required ? 'Input is required' : '')
           }
         })}
         {...baseFieldProps}


### PR DESCRIPTION
#132 added a regression where LabeledInputs got a name pattern by default.

* Zip: Should accept 5 or 9 digit zips. Zip+4 is not mandatory
* Phone: Should not accept phone numbers starting with 0 or 1
* Email: Regression caused labeled input to default to name pattern, which meant email addresses could not contain numbers or even @.
