### PR TITLE
Add docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# misc
+.DS_Store
+.netlify
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/.eslintcache
+
+# vscode settings
+/.vscode
+/.husky/
+/src/redux/validation.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.51-buster
+
+RUN apt-get update && apt-get -y upgrade
+
+# Install nvm, node, npm, and yarn
+ARG NVM_DIR="/root/.nvm"
+ARG NODE_VERSION=14.6.0
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh | bash
+RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION --latest-npm
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+RUN npm install -g yarn
+
+WORKDIR /app
+
+ADD ./package.json ./package.json
+ADD ./package-lock.json ./package-lock.json
+RUN npm install
+
+ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:1.51-buster
+FROM rust:1.51-slim-buster
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update && apt-get -y upgrade && apt-get install -y curl
 
 # Install nvm, node, npm, and yarn
 ARG NVM_DIR="/root/.nvm"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ This application can be either run as a web application or a standalone desktop 
 
 To run, `npm start` or `yarn start`.
 
+If preferred, a Docker alternative is available:
+```
+docker-compose build
+docker-compose up
+```
+Then, open a browser to `http://localhost:3000`.
+
 ### Desktop application
 
 For Windows users, please install [Microsoft Edge WebView2][WebView2] before running the desktop app

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ docker-compose up
 ```
 Then, open a browser to `http://localhost:3000`.
 
+To stop and remove running containers, run `docker-compose down`.
+
 ### Desktop application
 
 For Windows users, please install [Microsoft Edge WebView2][WebView2] before running the desktop app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  app:
+    build: .
+    command: npm run start
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./:/app
+      - /app/node_modules


### PR DESCRIPTION
**Purpose:**

Standardize local development environment among contributors and speed up time for new contributors to start coding.

For now, Docker is only available for the browser. The desktop application will need additional work before it can be used through Docker too. Ideally, we will also eventually use this setup for production deployment.

**Testing:**

```
docker-compose build
docker-compose up
```
Open a browser to `http://localhost:3000` and the website opens!