### PR TITLE
Replacing 'Taxpayer info' with 'Primary Taxpayer'

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -9,7 +9,7 @@ import W2JobInfo from './income/W2JobInfo'
 import CreatePDF from './createPDF'
 import ResponsiveDrawer, { item, Section, SectionItem } from './ResponsiveDrawer'
 import { PagerButtons, PagerContext, usePager } from './pager'
-import TaxPayerInfo from './TaxPayer'
+import PrimaryTaxpayer from './TaxPayer'
 import RefundBankAccount from './RefundBankAccount'
 import SpouseAndDependent from './TaxPayer/SpouseAndDependent'
 import ContactInfo from './TaxPayer/ContactInfo'
@@ -61,7 +61,7 @@ const drawerSections: Section[] = [
   {
     title: 'Personal',
     items: [
-      item('Primary Taxpayer Information', Urls.taxPayer.info, <TaxPayerInfo />),
+      item('Primary Taxpayer', Urls.taxPayer.info, <PrimaryTaxpayer />),
       item('Spouse and Dependents', Urls.taxPayer.spouseAndDependent, <SpouseAndDependent />),
       item('Filing Status', Urls.taxPayer.filingStatus, <FilingStatusSelect />),
       item('Contact Information', Urls.taxPayer.contactInfo, <ContactInfo />)

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -61,7 +61,7 @@ const drawerSections: Section[] = [
   {
     title: 'Personal',
     items: [
-      item('Taxpayer Information', Urls.taxPayer.info, <TaxPayerInfo />),
+      item('Primary Taxpayer Information', Urls.taxPayer.info, <TaxPayerInfo />),
       item('Spouse and Dependents', Urls.taxPayer.spouseAndDependent, <SpouseAndDependent />),
       item('Filing Status', Urls.taxPayer.filingStatus, <FilingStatusSelect />),
       item('Contact Information', Urls.taxPayer.contactInfo, <ContactInfo />)

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -27,7 +27,7 @@ const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
   role: PersonRole.PRIMARY
 })
 
-export default function TaxPayerInfo (): ReactElement {
+export default function PrimaryTaxpayer (): ReactElement {
   const { register, handleSubmit, control, errors } = useForm<PrimaryPerson>()
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -107,10 +107,9 @@ export default function TaxPayerInfo (): ReactElement {
         <Box display="flex" justifyContent="center">
           <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
             <Box display="flex" justifyContent="flex-start">
-              <h2>Taxpayer Information</h2>
+              <h2>Primary Taxpayer Information</h2>
             </Box>
 
-            <h4>Primary Taxpayer Information</h4>
             <PersonFields
               register={register}
               errors={errors}


### PR DESCRIPTION
This is sort of a minor nitpick but I think 'Primary Taxpayer' more clearly describes what the page contains. Removing the subtitle beneath the page title makes the flow a little cleaner as well. 
![image](https://user-images.githubusercontent.com/8848557/115351131-c5149d80-a16a-11eb-9a7e-a6e36e77a4cd.png)
![image](https://user-images.githubusercontent.com/8848557/115351413-1329a100-a16b-11eb-87af-435dbceebdc1.png)
