### PR TITLE
Fix earned income credit calculation function

### DIFF
--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -5,6 +5,7 @@ import { create1040 } from '../irsForms/Main'
 import { useSelector } from 'react-redux'
 import { Information, TaxesState } from '../redux/data'
 import { Check, Close } from '@material-ui/icons'
+import { Currency } from './input'
 
 interface BinaryStateListItemProps {
   active: boolean
@@ -74,6 +75,14 @@ const Summary = (): ReactElement => {
                           <span key={i}>{`${d?.firstName ?? ''} ${d?.lastName ?? ''}`}</span>
                         )
                       }
+                    </Typography>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      className={classes.inline}
+                      color="textPrimary"
+                    >
+                      <Currency value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)} />
                     </Typography>
                   </React.Fragment>
                 }

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -27,6 +27,9 @@ const useStyles = makeStyles((theme) => ({
   },
   inline: {
     display: 'inline'
+  },
+  block: {
+    display: 'block'
   }
 }))
 
@@ -47,10 +50,9 @@ const BinaryStateListItem = ({ active, children }: BinaryStateListItemProps): Re
 
 const Summary = (): ReactElement => {
   const state: Information = useSelector((state: TaxesState) => state.information)
+  const classes = useStyles()
 
   const f1040 = create1040(state)
-
-  const classes = useStyles()
 
   return (
     <PagerContext.Consumer>
@@ -67,8 +69,15 @@ const Summary = (): ReactElement => {
                     <Typography
                       component="span"
                       variant="body2"
-                      className={classes.inline}
                       color="textPrimary"
+                      className={classes.block}
+                    >
+                      Qualifying Dependents:
+                    </Typography>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      color="textSecondary"
                     >
                       {
                         f1040.scheduleEIC?.qualifyingDependents().map((d, i) =>
@@ -76,13 +85,13 @@ const Summary = (): ReactElement => {
                         )
                       }
                     </Typography>
+                    <br />
                     <Typography
                       component="span"
                       variant="body2"
-                      className={classes.inline}
                       color="textPrimary"
                     >
-                      <Currency value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)} />
+                      Credit: <Currency value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)} />
                     </Typography>
                   </React.Fragment>
                 }

--- a/src/data/federal.ts
+++ b/src/data/federal.ts
@@ -133,20 +133,41 @@ const federalBrackets: FederalBrackets = {
 const line11Caps = [15820, 41756, 47440, 50954]
 const line11MfjCaps = [21710, 47646, 53330, 56844]
 
-const unmarriedFormulas: Piecewise[] = [
-  // phase in             constant                phase out
-  [[0, linear(0.0765, 0)], [7030, linear(0, 538)], [8790, linear(-0.0765, (538 + 0.0765 * 8790))]],
-  [[0, linear(0.34, 0)], [10540, linear(0, 3584)], [19330, linear(-0.1598, (3584 + 0.1598 * 19330))]],
-  [[0, linear(0.40, 0)], [14800, linear(0, 5920)], [19330, linear(-0.2106, (5920 + 0.2106 * 19330))]],
-  [[0, linear(0.45, 0)], [14800, linear(0, 6660)], [19330, linear(-0.2106, (6660 + 0.2106 * 19330))]]
-]
+type Point = [number, number]
 
-const marriedFormulas: Piecewise[] = [
-  [[0, linear(0.0765, 0)], [7030, linear(0, 538)], [14680, linear(-0.0765, (538 + 0.0765 * 14680))]],
-  [[0, linear(0.34, 0)], [10540, linear(0, 3584)], [25220, linear(-0.1598, (3584 + 0.1598 * 19330))]],
-  [[0, linear(0.40, 0)], [14800, linear(0, 5920)], [25220, linear(-0.2106, (5920 + 0.2106 * 19330))]],
-  [[0, linear(0.45, 0)], [14800, linear(0, 6660)], [25220, linear(-0.2106, (6660 + 0.2106 * 19330))]]
-]
+// Provided
+const toPieceWise = (points: Point[]): Piecewise => (
+  points
+    .slice(0, points.length - 1)
+    .map((point, idx) => [point, points[idx + 1]])
+    .map(([[x1, y1], [x2, y2]]) =>
+      // starting point     slope              intercept
+      [x1, linear((y2 - y1) / (x2 - x1), y1 - x1 * (y2 - y1) / (x2 - x1))]
+    )
+)
+
+// These points are taken directly from IRS publication
+// IRS Rev. Proc. 2019-44 for tax year 2020
+// https://www.irs.gov/pub/irs-drop/rp-19-44.pdf
+const unmarriedFormulas: Piecewise[] = (() => {
+  const points: Point[][] = [
+    [[0, 0], [7030, 538], [8790, 3584], [15820, 0]], // 0
+    [[0, 0], [10540, 3584], [19330, 3584], [41756, 0]], // 1
+    [[0, 0], [14800, 5920], [19330, 5920], [47440, 0]], // 2
+    [[0, 0], [14800, 6660], [19330, 6660], [50954, 0]] // 3 or more
+  ]
+  return points.map((ps: Point[]) => toPieceWise(ps))
+})()
+
+const marriedFormulas: Piecewise[] = (() => {
+  const points: Point[][] = [
+    [[0, 0], [7030, 538], [14680, 3584], [21710, 0]], // 0
+    [[0, 0], [10540, 3584], [25220, 3584], [47646, 0]], // 1
+    [[0, 0], [14800, 5920], [25220, 5920], [53330, 0]], // 2
+    [[0, 0], [14800, 6660], [25220, 6660], [56844, 0]] // 3 or more
+  ]
+  return points.map((ps) => toPieceWise(ps))
+})()
 
 interface EICDef {
   caps: {[k in FilingStatus]: number[] | undefined}

--- a/src/data/federal.ts
+++ b/src/data/federal.ts
@@ -135,7 +135,8 @@ const line11MfjCaps = [21710, 47646, 53330, 56844]
 
 type Point = [number, number]
 
-// Provided
+// Provided a list of points, create a piecewise function
+// that makes linear segments through the list of points.
 const toPieceWise = (points: Point[]): Piecewise => (
   points
     .slice(0, points.length - 1)

--- a/src/irsForms/ScheduleEIC.test.ts
+++ b/src/irsForms/ScheduleEIC.test.ts
@@ -12,7 +12,7 @@ jest.mock('redux-persist', () => {
   const real = jest.requireActual('redux-persist')
   return {
     ...real,
-    persistReducer: jest.fn().mockImplementation((config, reducers) => reducers)
+    persistReducer: jest.fn().mockImplementation((_, reducers) => reducers)
   }
 })
 

--- a/src/irsForms/ScheduleEIC.test.ts
+++ b/src/irsForms/ScheduleEIC.test.ts
@@ -16,12 +16,9 @@ jest.mock('redux-persist', () => {
   }
 })
 
-beforeAll(async () => {
-  jest.spyOn(console, 'log').mockImplementation(() => {})
+beforeAll(async () =>
   jest.spyOn(console, 'warn').mockImplementation(() => {})
-  jest.spyOn(console, 'info').mockImplementation(() => {})
-  jest.spyOn(console, 'debug').mockImplementation(() => {})
-})
+)
 
 describe('ScheduleEIC', () => {
   it('should disallow EIC for no income', () => {

--- a/src/irsForms/ScheduleEIC.test.ts
+++ b/src/irsForms/ScheduleEIC.test.ts
@@ -1,0 +1,52 @@
+import { waitFor } from '@testing-library/react'
+import { FilingStatus, PersonRole, TaxesState } from '../redux/data'
+import ScheduleEIC from './ScheduleEIC'
+import F1040 from './F1040'
+
+afterEach(async () => {
+  await waitFor(() => localStorage.clear())
+  jest.resetAllMocks()
+})
+
+jest.mock('redux-persist', () => {
+  const real = jest.requireActual('redux-persist')
+  return {
+    ...real,
+    persistReducer: jest.fn().mockImplementation((config, reducers) => reducers)
+  }
+})
+
+beforeAll(async () => {
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+  jest.spyOn(console, 'info').mockImplementation(() => {})
+  jest.spyOn(console, 'debug').mockImplementation(() => {})
+})
+
+describe('ScheduleEIC', () => {
+  it('should disallow EIC for no income', () => {
+    const model: TaxesState = {
+      information: {
+        f1099s: [],
+        w2s: [],
+        taxPayer: {
+          filingStatus: FilingStatus.MFJ,
+          dependents: [],
+          spouse: {
+            isTaxpayerDependent: false,
+            firstName: 'a',
+            lastName: 'b',
+            ssid: '123456789',
+            role: PersonRole.SPOUSE
+          }
+        }
+      }
+    }
+    const f1040 = new F1040(model.information.taxPayer)
+    model.information.w2s.forEach((w2) => f1040.addW2(w2))
+
+    const eic = new ScheduleEIC(model.information.taxPayer)
+    expect(eic.allowed(f1040)).toBe(false)
+    expect(eic.credit(f1040)).toBe(0)
+  })
+})

--- a/src/irsForms/ScheduleEIC.ts
+++ b/src/irsForms/ScheduleEIC.ts
@@ -210,13 +210,19 @@ export default class ScheduleEIC implements Form {
     return l9
   }
 
+  /**
+   * The credit table in Publication 596 provides an
+   * amount for each interval of $50, calculated from the
+   * midpoint of the interval.
+   *
+   * @param income The earned income
+   * @returns the earned income rounded to the nearest 25
+   */
   roundIncome = (income: number): number => {
-    const intIncome = Math.round(income)
-    const mod = intIncome % 50
-    if (mod < 25) {
-      return Math.round(income / 50) * 50 + 25
+    if (income < 1) {
+      return 0
     }
-    return income
+    return Math.round(Math.round(income) / 50) * 50 + 25
   }
 
   /**
@@ -238,9 +244,6 @@ export default class ScheduleEIC implements Form {
    * that is found in the table is calculated based on an income of $5025 and
    * comes out ahead. Conversely, someone with an earned income of $5049 finds
    * a credit in the table calculated off the same $5,025 and loses out.
-   *
-   * So our calculator rounds up to the middle of a $50 interval if necessary
-   * before applying the credit formula.
    *
    * https://www.irs.gov/pub/irs-pdf/p596.pdf
    *

--- a/src/irsForms/ScheduleEIC.ts
+++ b/src/irsForms/ScheduleEIC.ts
@@ -65,7 +65,7 @@ export default class ScheduleEIC implements Form {
     if (this.tp.tp.filingStatus !== undefined) {
       const incomeLimits = federal.EIC.caps[this.tp.tp.filingStatus]
       if (incomeLimits !== undefined) {
-        const limit = incomeLimits[Math.min(this.qualifyingDependents.length, incomeLimits.length - 1)]
+        const limit = incomeLimits[Math.min(this.qualifyingDependents().length, incomeLimits.length - 1)]
         return (f1040.l11() ?? 0) < limit
       }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,14 @@ export const linear = (m: number, b: number) => (x: number): number => b + m * x
 export type Piecewise = Array<[number, ((x: number) => number)]>
 
 export const evaluatePiecewise = (f: Piecewise, x: number): number => {
-  // select the piece of the function that we are in.
-  const selection: number = Math.max(f.findIndex(([lowerBound]) => lowerBound > x), f.length) - 1
+  // Select the function segment to evaulate.
+  // The function segment is the one before the segment with the lower bound above x.
+  const selection: number = (() => {
+    const idx = f.findIndex(([lowerBound]) => lowerBound > x)
+    if (idx < 0) {
+      return f.length - 1
+    }
+    return idx - 1
+  })()
   return f[selection][1](x)
 }


### PR DESCRIPTION
Piecewise function evaluation was always selecting the upper (phase out) segment for any input.

Also add no income => no earned income credit test.