### PR TITLE
coalesce undefined values false as starting value

### DIFF
--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -114,7 +114,7 @@ export default function PrimaryTaxpayer (): ReactElement {
             <LabeledCheckbox
               label="Check if you are a dependent"
               control={control}
-              defaultValue={taxPayer?.primaryPerson?.isTaxpayerDependent}
+              defaultValue={taxPayer?.primaryPerson?.isTaxpayerDependent ?? false}
               name="isTaxpayerDependent"
             />
             <LabeledInput


### PR DESCRIPTION
Fixes: 
![image](https://user-images.githubusercontent.com/8848557/117227480-b9acad80-adcb-11eb-8e59-f66ad17c640a.png)
when starting out and submitting primary taxpayer information without the dependent checkbox checked