### PR TITLE
Refactor forms to better separate concerns

### DIFF
--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -7,6 +7,7 @@ import { Information, TaxesState } from '../redux/data'
 import { Check, Close } from '@material-ui/icons'
 import { Currency } from './input'
 import Alert from '@material-ui/lab/Alert'
+import { isLeft } from '../util'
 
 interface BinaryStateListItemProps {
   active: boolean
@@ -64,26 +65,25 @@ const Summary = (): ReactElement => {
                 <h4>No data entered yet</h4>
               )
             } else {
-              const { result, errors } = create1040(state)
-              const f1040 = result?.[0]
+              const f1040Result = create1040(state)
 
-              if (result === undefined) {
+              if (isLeft(f1040Result)) {
+                const errors = f1040Result.left
+
                 return (
                   <Fragment>
-                    {errors?.map((error, i) => <Alert key={i} severity="warning">{error}</Alert>)}
+                    {errors.map((error, i) => <Alert key={i} severity="warning">{error}</Alert>)}
                   </Fragment>
                 )
-              } else if (f1040 === undefined) {
-                // create1040 returns either a result or errors, but we don't really have
-                // a good Either<E, A> type right now. This case should never happen.
-                throw new Error('1040 was undefined.')
               }
+
+              const [f1040] = f1040Result.right
 
               return (
                 <Fragment>
                   <h4>Credits</h4>
                   <List>
-                    <BinaryStateListItem active={f1040.scheduleEIC?.allowed(result?.[0]) ?? false} >
+                    <BinaryStateListItem active={f1040.scheduleEIC?.allowed(f1040) ?? false} >
                       <ListItemText
                         primary="Earned Income Tax Credit"
                         secondary={

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux'
 import { Information, TaxesState } from '../redux/data'
 import { Check, Close } from '@material-ui/icons'
 import { Currency } from './input'
+import Alert from '@material-ui/lab/Alert'
 
 interface BinaryStateListItemProps {
   active: boolean
@@ -63,13 +64,26 @@ const Summary = (): ReactElement => {
                 <h4>No data entered yet</h4>
               )
             } else {
-              const [f1040] = create1040(state)
+              const { result, errors } = create1040(state)
+              const f1040 = result?.[0]
+
+              if (result === undefined) {
+                return (
+                  <Fragment>
+                    {errors?.map((error, i) => <Alert key={i} severity="warning">{error}</Alert>)}
+                  </Fragment>
+                )
+              } else if (f1040 === undefined) {
+                // create1040 returns either a result or errors, but we don't really have
+                // a good Either<E, A> type right now. This case should never happen.
+                throw new Error('1040 was undefined.')
+              }
 
               return (
                 <Fragment>
                   <h4>Credits</h4>
                   <List>
-                    <BinaryStateListItem active={f1040.scheduleEIC?.allowed(f1040) ?? false} >
+                    <BinaryStateListItem active={f1040.scheduleEIC?.allowed(result?.[0]) ?? false} >
                       <ListItemText
                         primary="Earned Income Tax Credit"
                         secondary={

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -52,7 +52,7 @@ const Summary = (): ReactElement => {
   const state: Information = useSelector((state: TaxesState) => state.information)
   const classes = useStyles()
 
-  const f1040 = create1040(state)
+  const [f1040] = create1040(state)
 
   return (
     <PagerContext.Consumer>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import React, { Fragment, ReactElement } from 'react'
 import { List, ListItem, ListItemAvatar, ListItemIcon, ListItemText, makeStyles, Typography } from '@material-ui/core'
 import { PagerContext } from './pager'
 import { create1040 } from '../irsForms/Main'
@@ -52,52 +52,64 @@ const Summary = (): ReactElement => {
   const state: Information = useSelector((state: TaxesState) => state.information)
   const classes = useStyles()
 
-  const [f1040] = create1040(state)
-
   return (
     <PagerContext.Consumer>
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={onAdvance}>
           <h2>Summary</h2>
-          <h4>Credits</h4>
-          <List>
-            <BinaryStateListItem active={f1040.scheduleEIC?.allowed(f1040) ?? false} >
-              <ListItemText
-                primary="Earned Income Tax Credit"
-                secondary={
-                  <React.Fragment>
-                    <Typography
-                      component="span"
-                      variant="body2"
-                      color="textPrimary"
-                      className={classes.block}
-                    >
-                      Qualifying Dependents:
-                    </Typography>
-                    <Typography
-                      component="span"
-                      variant="body2"
-                      color="textSecondary"
-                    >
-                      {
-                        f1040.scheduleEIC?.qualifyingDependents().map((d, i) =>
-                          <span key={i}>{`${d?.firstName ?? ''} ${d?.lastName ?? ''}`}</span>
-                        )
-                      }
-                    </Typography>
-                    <br />
-                    <Typography
-                      component="span"
-                      variant="body2"
-                      color="textPrimary"
-                    >
-                      Credit: <Currency value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)} />
-                    </Typography>
-                  </React.Fragment>
-                }
-              />
-            </BinaryStateListItem>
-          </List>
+          {(() => {
+            if (state.taxPayer.primaryPerson === undefined) {
+              return (
+                <h4>No data entered yet</h4>
+              )
+            } else {
+              const [f1040] = create1040(state)
+
+              return (
+                <Fragment>
+                  <h4>Credits</h4>
+                  <List>
+                    <BinaryStateListItem active={f1040.scheduleEIC?.allowed(f1040) ?? false} >
+                      <ListItemText
+                        primary="Earned Income Tax Credit"
+                        secondary={
+                          <React.Fragment>
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              color="textPrimary"
+                              className={classes.block}
+                            >
+                              Qualifying Dependents:
+                            </Typography>
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              color="textSecondary"
+                            >
+                              {
+                                f1040.scheduleEIC?.qualifyingDependents().map((d, i) =>
+                                  <span key={i}>{`${d?.firstName ?? ''} ${d?.lastName ?? ''}`}</span>
+                                )
+                              }
+                            </Typography>
+                            <br />
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              color="textPrimary"
+                            >
+                              Credit: <Currency value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)} />
+                            </Typography>
+                          </React.Fragment>
+                        }
+                      />
+                    </BinaryStateListItem>
+                  </List>
+                </Fragment>
+              )
+            }
+          })()}
           {navButtons}
        </form>
       }

--- a/src/components/createPDF.tsx
+++ b/src/components/createPDF.tsx
@@ -37,11 +37,11 @@ export default function CreatePDF (): ReactElement {
         <form onSubmit={onSubmit}>
           <div>
             <h2>Print Copy to File</h2>
-            {navButtons}
           </div>
           <div className={classes.root}>
             {errors.map((error, i) => <Alert key={i} severity="warning">{error}</Alert>)}
           </div>
+          {navButtons}
         </form>
       }
     </PagerContext.Consumer>

--- a/src/irsForms/F1040.ts
+++ b/src/irsForms/F1040.ts
@@ -14,7 +14,7 @@ import ScheduleA from './ScheduleA'
 import ScheduleD from './ScheduleD'
 import ScheduleE from './ScheduleE'
 import ScheduleEIC from './ScheduleEIC'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import { displayNumber, computeField, sumFields } from './util'
 import ScheduleB from './ScheduleB'
 import { computeOrdinaryTax } from './TaxTable'
@@ -25,6 +25,7 @@ export enum F1040Error {
 }
 
 export default class F1040 implements Form {
+  tag: FormTag = 'f1040'
   // intentionally mirroring many fields from the state,
   // trying to represent the fields that the 1040 requires
   filingStatus?: FilingStatus

--- a/src/irsForms/F1040v.ts
+++ b/src/irsForms/F1040v.ts
@@ -1,8 +1,9 @@
 import { Information } from '../redux/data'
 import F1040 from './F1040'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 
 export default class F1040V implements Form {
+  tag: FormTag = 'f1040v'
   state: Information
   f1040: F1040
 

--- a/src/irsForms/Form.ts
+++ b/src/irsForms/Form.ts
@@ -1,9 +1,18 @@
 
+export type FormTag =
+  'f1040' |
+  'f1040v' |
+  'f1040s1' |
+  'f1040sb' |
+  'f1040sd' |
+  'f1040se' |
+  'f1040sei'
 /**
   * Base interface for what every form implementation should include.
   * Any PDF can be filled from an array of values.
   *
   */
 export default interface Form {
+  tag: FormTag
   fields: () => Array<string | number | boolean | undefined>
 }

--- a/src/irsForms/Main.ts
+++ b/src/irsForms/Main.ts
@@ -1,4 +1,5 @@
 import { Income1099Type, Information } from '../redux/data'
+import { Either, left, right } from '../util'
 import F1040, { F1040Error } from './F1040'
 import F1040V from './F1040v'
 import Form from './Form'
@@ -52,7 +53,7 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
   return [...prepends, f1040, ...attachments]
 }
 
-export function create1040 (state: Information): { result?: [F1040, Form[]], errors?: F1040Error[] } {
+export function create1040 (state: Information): Either<F1040Error[], [F1040, Form[]]> {
   const f1040 = new F1040(state.taxPayer)
 
   state.w2s.forEach((w2) => f1040.addW2(w2))
@@ -62,8 +63,8 @@ export function create1040 (state: Information): { result?: [F1040, Form[]], err
   }
 
   if (f1040.errors().length > 0) {
-    return { errors: f1040.errors() }
+    return left(f1040.errors())
   }
 
-  return { result: [f1040, getSchedules(f1040, state)] }
+  return right([f1040, getSchedules(f1040, state)])
 }

--- a/src/irsForms/Main.ts
+++ b/src/irsForms/Main.ts
@@ -1,5 +1,5 @@
 import { Income1099Type, Information } from '../redux/data'
-import F1040 from './F1040'
+import F1040, { F1040Error } from './F1040'
 import F1040V from './F1040v'
 import Form from './Form'
 import Schedule1 from './Schedule1'
@@ -52,7 +52,7 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
   return [...prepends, f1040, ...attachments]
 }
 
-export function create1040 (state: Information): [F1040, Form[]] {
+export function create1040 (state: Information): { result?: [F1040, Form[]], errors?: F1040Error[] } {
   const f1040 = new F1040(state.taxPayer)
 
   state.w2s.forEach((w2) => f1040.addW2(w2))
@@ -62,8 +62,8 @@ export function create1040 (state: Information): [F1040, Form[]] {
   }
 
   if (f1040.errors().length > 0) {
-    throw new Error(f1040.errors().join('\n'))
+    return { errors: f1040.errors() }
   }
 
-  return [f1040, getSchedules(f1040, state)]
+  return { result: [f1040, getSchedules(f1040, state)] }
 }

--- a/src/irsForms/Schedule1.ts
+++ b/src/irsForms/Schedule1.ts
@@ -1,7 +1,7 @@
 import { Information } from '../redux/data'
 import TaxPayer from '../redux/TaxPayer'
 import { anArrayOf } from '../util'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import ScheduleE from './ScheduleE'
 import { sumFields } from './util'
 
@@ -9,6 +9,7 @@ const unimplemented = (message: string): void =>
   console.warn(`[Schedule 1] unimplemented ${message}`)
 
 export default class Schedule1 implements Form {
+  tag: FormTag = 'f1040s1'
   state: Information
   scheduleE?: ScheduleE
 

--- a/src/irsForms/ScheduleB.ts
+++ b/src/irsForms/ScheduleB.ts
@@ -1,6 +1,6 @@
 import { Income1099Type, Information, Income1099Int, Income1099Div } from '../redux/data'
 import TaxPayer from '../redux/TaxPayer'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import { computeField, displayNumber, sumFields } from './util'
 import { anArrayOf } from '../util'
 
@@ -10,6 +10,7 @@ interface PayerAmount {
 }
 
 export default class ScheduleB implements Form {
+  tag: FormTag = 'f1040sb'
   state: Information
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16

--- a/src/irsForms/ScheduleD.ts
+++ b/src/irsForms/ScheduleD.ts
@@ -6,13 +6,14 @@ import {
   F1099BData,
   FilingStatus
 } from '../redux/data'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import TaxPayer from '../redux/TaxPayer'
 import { computeField, displayNumber, sumFields } from './util'
 import SDRateGainWorksheet from './worksheets/SDRateGainWorksheet'
 import SDUnrecaptured1250 from './worksheets/SDUnrecaptured1250'
 
 export default class ScheduleD implements Form {
+  tag: FormTag = 'f1040sd'
   state: Information
   aggregated: F1099BData
   rateGainWorksheet: SDRateGainWorksheet

--- a/src/irsForms/ScheduleE.ts
+++ b/src/irsForms/ScheduleE.ts
@@ -1,5 +1,5 @@
 import { Address, Information, Property, PropertyType, PropertyExpenseTypeName } from '../redux/data'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import TaxPayer from '../redux/TaxPayer'
 import { anArrayOf, unzip3, zip, zip3 } from '../util'
 import F6168 from './F6168'
@@ -37,6 +37,7 @@ const propTypeIndex = {
 }
 
 export default class ScheduleE implements Form {
+  tag: FormTag = 'f1040se'
   state: Information
   f6168: F6168
   f8582: F8582

--- a/src/irsForms/ScheduleEIC.ts
+++ b/src/irsForms/ScheduleEIC.ts
@@ -7,7 +7,7 @@ import F2555 from './F2555'
 import F4797 from './F4797'
 import F8814 from './F8814'
 import Pub596Worksheet1 from './worksheets/Pub596Worksheet1'
-import Form from './Form'
+import Form, { FormTag } from './Form'
 import { anArrayOf, evaluatePiecewise, Piecewise } from '../util'
 
 type PrecludesEIC<F> = (f: F) => boolean
@@ -43,6 +43,7 @@ const precludesEIC = <F>(p: PrecludesEIC<F>) => (f: F | undefined) => {
 }
 
 export default class ScheduleEIC implements Form {
+  tag: FormTag = 'f1040sei'
   tp: TaxPayer
   f2555?: F2555
   f4797?: F4797

--- a/src/pdfFiller/fillPdf.ts
+++ b/src/pdfFiller/fillPdf.ts
@@ -45,8 +45,17 @@ export async function create1040PDF (): Promise<Uint8Array> {
   const state = store.getState().information
 
   if (state.taxPayer !== undefined) {
-    const [,forms] = create1040(state)
+    const { result, errors } = create1040(state)
     // Get data and pdf links applicable to the model state
+    if (errors !== undefined) {
+      return await Promise.reject(errors)
+    } else if (result === undefined) {
+      // This should never happen, since create1040 is supposd to
+      // return either result or errors.
+      return await Promise.reject(new Error('No F1040 was generated'))
+    }
+
+    const [,forms] = result
     const pdfs: PDFDocument[] = await Promise.all(forms.map(async (f) => await downloadPDF(`/forms/${f.tag}.pdf`)))
     const formData: Array<[Form, PDFDocument]> = zip(forms, pdfs)
 

--- a/src/pdfFiller/fillPdf.ts
+++ b/src/pdfFiller/fillPdf.ts
@@ -8,7 +8,7 @@ import { store } from '../redux/store'
 import { savePdf } from './pdfHandler'
 import Form from '../irsForms/Form'
 import { create1040 } from '../irsForms/Main'
-import { zip } from '../util'
+import { isLeft, zip } from '../util'
 
 /**
   * Attempt to fill fields in a PDF from a Form,
@@ -45,17 +45,13 @@ export async function create1040PDF (): Promise<Uint8Array> {
   const state = store.getState().information
 
   if (state.taxPayer !== undefined) {
-    const { result, errors } = create1040(state)
+    const f1040Result = create1040(state)
     // Get data and pdf links applicable to the model state
-    if (errors !== undefined) {
-      return await Promise.reject(errors)
-    } else if (result === undefined) {
-      // This should never happen, since create1040 is supposd to
-      // return either result or errors.
-      return await Promise.reject(new Error('No F1040 was generated'))
+    if (isLeft(f1040Result)) {
+      return await Promise.reject(f1040Result.left)
     }
 
-    const [,forms] = result
+    const [,forms] = f1040Result.right
     const pdfs: PDFDocument[] = await Promise.all(forms.map(async (f) => await downloadPDF(`/forms/${f.tag}.pdf`)))
     const formData: Array<[Form, PDFDocument]> = zip(forms, pdfs)
 

--- a/src/pdfFiller/fillPdf.ts
+++ b/src/pdfFiller/fillPdf.ts
@@ -6,25 +6,9 @@ import {
 } from 'pdf-lib'
 import { store } from '../redux/store'
 import { savePdf } from './pdfHandler'
-import F1040 from '../irsForms/F1040'
 import Form from '../irsForms/Form'
-import ScheduleB from '../irsForms/ScheduleB'
-import { Income1099Type } from '../redux/data'
-import ScheduleD from '../irsForms/ScheduleD'
-import ScheduleEIC from '../irsForms/ScheduleEIC'
-import F1040V from '../irsForms/F1040v'
-import ScheduleE from '../irsForms/ScheduleE'
-import Schedule1 from '../irsForms/Schedule1'
-
-const downloadUrls = {
-  f1040: '/forms/f1040.pdf',
-  f1040s1: '/forms/f1040s1.pdf',
-  f1040sb: '/forms/f1040sb.pdf',
-  f1040sd: '/forms/f1040sd.pdf',
-  f1040se: '/forms/f1040se.pdf',
-  f1040sei: '/forms/f1040sei.pdf',
-  f1040v: '/forms/f1040v.pdf'
-}
+import { create1040 } from '../irsForms/Main'
+import { zip } from '../util'
 
 /**
   * Attempt to fill fields in a PDF from a Form,
@@ -56,82 +40,19 @@ async function downloadPDF (url: string): Promise<PDFDocument> {
   return await PDFDocument.load(buffer)
 }
 
-async function getSchedules (f1040: F1040): Promise<Array<[Form, PDFDocument]>> {
-  const state = store.getState().information
-  let attachments: Array<[Form, PDFDocument]> = []
-  const prepends: Array<[Form, PDFDocument]> = []
-
-  if (state.f1099s.find((v) => v.type === Income1099Type.INT) !== undefined) {
-    const schB = new ScheduleB(state)
-
-    const schBPdf = await downloadPDF(downloadUrls.f1040sb)
-
-    f1040.addScheduleB(schB)
-    attachments = [...attachments, [schB, schBPdf]]
-  }
-
-  if (state.f1099s.find((v) => v.type === Income1099Type.B) !== undefined) {
-    const schD = new ScheduleD(state)
-    const schDPdf = await downloadPDF(downloadUrls.f1040sd)
-    f1040.addScheduleD(schD)
-    attachments = [...attachments, [schD, schDPdf]]
-  }
-
-  const eic = new ScheduleEIC(state.taxPayer)
-  if (eic.allowed(f1040)) {
-    const eicPdf = await downloadPDF(downloadUrls.f1040sei)
-    f1040.addScheduleEIC(eic)
-    attachments = [...attachments, [eic, eicPdf]]
-  }
-
-  if (state.realEstate.length > 0) {
-    const se = new ScheduleE(state)
-    const sePdf = await downloadPDF(downloadUrls.f1040se)
-    f1040.addScheduleE(se)
-    attachments = [...attachments, [se, sePdf]]
-  }
-
-  if (f1040.scheduleE !== undefined) {
-    const s1 = new Schedule1(state)
-    const s1Pdf = await downloadPDF(downloadUrls.f1040s1)
-    s1.addScheduleE(f1040.scheduleE)
-    f1040.addSchedule1(s1)
-    attachments = [[s1, s1Pdf], ...attachments]
-  }
-
-  // Attach payment voucher to front if there is a payment due
-  if ((f1040.l37() ?? 0) > 0) {
-    const f1040v = new F1040V(state, f1040)
-    const f1040vPdf = await downloadPDF(downloadUrls.f1040v)
-    prepends.push([f1040v, f1040vPdf])
-  }
-
-  const f1040pdf: PDFDocument = await downloadPDF(downloadUrls.f1040)
-  return [...prepends, [f1040, f1040pdf], ...attachments]
-}
-
 // opens new with filled information in the window of the component it is called from
-export async function create1040 (): Promise<Uint8Array> {
+export async function create1040PDF (): Promise<Uint8Array> {
   const state = store.getState().information
 
   if (state.taxPayer !== undefined) {
-    const f1040 = new F1040(state.taxPayer)
-
-    if (f1040.errors().length > 0) {
-      return await Promise.reject(f1040.errors())
-    }
-
-    state.w2s.forEach((w2) => f1040.addW2(w2))
-    if (state.refund !== undefined) {
-      f1040.addRefund(state.refund)
-    }
-
-    // Get blank pdfs applicable to the model state
-    const files: Array<[Form, PDFDocument]> = await getSchedules(f1040)
+    const [,forms] = create1040(state)
+    // Get data and pdf links applicable to the model state
+    const pdfs: PDFDocument[] = await Promise.all(forms.map(async (f) => await downloadPDF(`/forms/${f.tag}.pdf`)))
+    const formData: Array<[Form, PDFDocument]> = zip(forms, pdfs)
 
     // Insert the values from each field into the PDF
-    const pdfFiles: Array<Promise<PDFDocument>> = files.map(async ([formData, f]) => {
-      fillPDF(f, formData)
+    const pdfFiles: Array<Promise<PDFDocument>> = formData.map(async ([data, f]) => {
+      fillPDF(f, data)
       const pageBytes = await f.save()
       return await PDFDocument.load(pageBytes)
     })
@@ -160,6 +81,6 @@ export async function create1040 (): Promise<Uint8Array> {
 
 // opens new with filled information in the window of the component it is called from
 export async function createPDFPopup (): Promise<void> {
-  const pdfBytes = await create1040()
+  const pdfBytes = await create1040PDF()
   return await savePdf(pdfBytes)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -71,3 +71,22 @@ export const isLeapYear = (year: number): boolean => {
 
 export const daysInYear = (year: number): number =>
   isLeapYear(year) ? 366 : 365
+
+// idea from https://github.com/gcanti/fp-ts/blob/3e2af038982cb4090ccc8c2912e4b22f907bdaea/src/Either.ts
+export interface Left<E> {
+  readonly _tag: 'left'
+  left: E
+}
+
+export interface Right<A> {
+  readonly _tag: 'right'
+  right: A
+}
+
+export type Either<E, A> = Left<E> | Right<A>
+
+export const left = <E = never, A = never>(left: E): Either <E, A> => ({ _tag: 'left', left })
+export const right = <E = never, A = never>(right: A): Either<E, A> => ({ _tag: 'right', right })
+
+export const isLeft = <E, A>(e: Either<E, A>): e is Left<E> => e._tag === 'left'
+export const isRight = <E, A>(e: Either<E, A>): e is Right<A> => e._tag === 'right'


### PR DESCRIPTION
I'm trying to better separate the PDF filling from the form assembly.

The functions in irsForms/Main complete all calculations and produce an array of forms, then pdfFiller/fillPdf takes that array of forms and pushes the data into the actual PDFDocuments.

Fixes an old factoring problem where there were two separate implementations of a function `getSchedules` that both tried to do the same thing.

This way we can create the complete data model for what will be inserted into the PDF, and probe it for correctness and for display.

Also changed return type for `create1040` so that the errors are returned explicitly.