### PR TITLE
Add crypto and Schedule B Part III questions

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -29,6 +29,7 @@ import Summary from './Summary'
 import RealEstate from './income/RealEstate'
 import { StateLoader } from './debug'
 import NoMatchPage from './NoMatchPage'
+import Questions from './Questions'
 
 const theme = createMuiTheme({
   palette: {
@@ -86,6 +87,7 @@ const Urls = {
     contactInfo: '/contact'
   },
   refund: '/refundinfo',
+  questions: '/questions',
   income: {
     w2s: '/income/w2jobinfo',
     f1099s: '/income/f1099s',
@@ -122,6 +124,7 @@ const drawerSections: Section[] = [
     title: 'Results',
     items: [
       item('Refund Information', Urls.refund, <RefundBankAccount />),
+      item('Informational Questions', Urls.questions, <Questions />),
       item('Summary', Urls.summary, <Summary />),
       item('Review and Print', Urls.createPdf, <CreatePDF />)
     ]

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import { List, ListItem } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
-import { getRequiredQuestions, Responses } from '../data/questions'
+import { getRequiredQuestions, QuestionTagName, Responses } from '../data/questions'
 import { TaxesState } from '../redux/data'
 import { answerQuestion } from '../redux/actions'
 import { LabeledCheckbox, LabeledInput } from './input'
@@ -28,7 +28,16 @@ const Questions = (): ReactElement => {
   const dispatch = useDispatch()
 
   const onSubmit = (onAdvance: () => void) => (responses: Responses): void => {
-    dispatch(answerQuestion(responses))
+    // fix to remove unrequired answers:
+    const qtags = questions.map((q) => q.tag)
+    const unrequired = Object.keys(responses).filter((rtag) => qtags.find((t) => t === rtag as QuestionTagName) === undefined)
+
+    const newResponses = {
+      ...responses,
+      ...Object.fromEntries(unrequired.map((k) => [k, undefined]))
+    }
+
+    dispatch(answerQuestion(newResponses))
     onAdvance()
   }
 

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement } from 'react'
+import { List, ListItem } from '@material-ui/core'
+import { useDispatch, useSelector } from 'react-redux'
+import { getRequiredQuestions, QuestionTag } from '../data/questions'
+import { TaxesState } from '../redux/data'
+import { answerQuestion } from '../redux/actions'
+import { LabeledCheckbox } from './input'
+import { useForm } from 'react-hook-form'
+import { enumKeys } from '../util'
+import { PagerContext } from './pager'
+
+type Responses = {[k in keyof typeof QuestionTag]: boolean}
+
+const Questions = (): ReactElement => {
+  const state = useSelector((state: TaxesState) => state)
+  const questions = getRequiredQuestions(state)
+
+  const { control, handleSubmit } = useForm<Responses>({
+    defaultValues: Object.fromEntries(enumKeys(QuestionTag).map((x) => [x, false])) as Responses
+  })
+
+  const dispatch = useDispatch()
+
+  const onSubmit = (onAdvance: () => void) => (responses: Responses): void => {
+    Object.entries(responses).forEach(([tag, value]) => {
+      dispatch(answerQuestion({ tag: tag as keyof typeof QuestionTag, value }))
+    })
+    onAdvance()
+  }
+
+  return (
+    <PagerContext.Consumer>
+      { ({ onAdvance, navButtons }) =>
+        <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
+          <h2>Informational Questions</h2>
+          <p>Based on your prior responses, reseponses to these questions are required.</p>
+          <List>
+            {
+              questions.map((q, i) =>
+                <ListItem key={i}>
+                  <LabeledCheckbox
+                    name={QuestionTag[q.tag]}
+                    label={q.text}
+                    control={control}
+                  />
+                </ListItem>
+              )
+            }
+          </List>
+          {navButtons}
+        </form>
+      }
+    </PagerContext.Consumer>
+  )
+}
+
+export default Questions

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -10,9 +10,20 @@ import { PagerContext } from './pager'
 
 const Questions = (): ReactElement => {
   const state = useSelector((state: TaxesState) => state)
-  const questions = getRequiredQuestions(state)
 
-  const { control, register, handleSubmit } = useForm<Responses>()
+  const { control, register, handleSubmit, watch } = useForm<Responses>()
+
+  const currentValues = watch()
+
+  const questions = getRequiredQuestions({
+    information: {
+      ...state.information,
+      questions: {
+        ...state.information.questions,
+        ...currentValues
+      }
+    }
+  })
 
   const dispatch = useDispatch()
 

--- a/src/components/input/LabeledCheckbox.tsx
+++ b/src/components/input/LabeledCheckbox.tsx
@@ -12,7 +12,7 @@ export function LabeledCheckbox (props: LabeledCheckboxProps): ReactElement {
   return (
     <Controller
       name={name}
-      defaultValue={defaultValue}
+      defaultValue={defaultValue ?? false}
       render={ ({ value, onChange }) =>
         <div className={classes.root}>
           <FormControl component="fieldset">

--- a/src/data/federal.ts
+++ b/src/data/federal.ts
@@ -173,7 +173,6 @@ const marriedFormulas: Piecewise[] = (() => {
 
 interface EICDef {
   caps: {[k in FilingStatus]: number[] | undefined}
-  questions: Array<[string, boolean]>
   maxInvestmentIncome: number
   formulas: { [k in FilingStatus]: Piecewise[] | undefined }
 }
@@ -188,21 +187,6 @@ export const EIC: EICDef = {
     [FilingStatus.MFS]: undefined,
     [FilingStatus.MFJ]: line11MfjCaps
   },
-  // step 1 required questions
-  questions: [
-    [
-      'Do you, and your spouse if filing a joint return, have a social security number issued on or before the due date of your 2020 return (including extensions) that allows you to work and is valid for EIC purposes (explained later under Definitions and Special Rules)?',
-      true
-    ],
-    [
-      'Are you filing Form 2555 (relating to foreign earned income)?',
-      false
-    ],
-    [
-      'Were you or your spouse a nonresident alien for any part of 2020?',
-      false
-    ]
-  ],
   maxInvestmentIncome: 3650,
   formulas: {
     [FilingStatus.S]: unmarriedFormulas,

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,0 +1,30 @@
+import { TaxesState } from '../redux/data'
+import { Either, isLeft, isRight, left } from '../util'
+
+export enum QuestionTag {
+  CRYPTO
+}
+
+// type QuestionTagName = keyof typeof QuestionTag
+
+export interface Question {
+  text: string
+  required: Either<boolean, (state: TaxesState) => boolean>
+  tag: QuestionTag
+}
+
+// function q (tag: QuestionTag, text: string, required: ((s: TaxesState) => boolean)): Question {
+//   return { text, tag, required: right(required) }
+// }
+
+function qr (tag: QuestionTag, text: string): Question {
+  return { text, tag, required: left(true) }
+}
+
+export const questions: Question[] = [
+  qr(QuestionTag.CRYPTO, 'Do you have any crypto-currency transactions?')
+]
+
+export const getRequiredQuestions = (state: TaxesState): Question[] => questions.filter((q) =>
+  isLeft(q.required) || (isRight(q.required) && q.required.right(state))
+)

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,28 +1,73 @@
 import { TaxesState } from '../redux/data'
-import { Either, isLeft, isRight, left } from '../util'
+import { Either, isLeft, isRight, left, right } from '../util'
 
-export enum QuestionTag {
-  CRYPTO
+// Defines usable tag names for each question later defined,
+// and maps to a type which is the expected response type.
+export interface QuestionTag {
+  CRYPTO: boolean
+  FOREIGN_ACCOUNT_EXISTS: boolean
+  FINCEN_114: boolean
+  FINCEN_114_ACCOUNT_COUNTRY: string
+  FOREIGN_TRUST_RELATIONSHIP: boolean
 }
 
-// type QuestionTagName = keyof typeof QuestionTag
+export type QuestionTagName = keyof QuestionTag
+
+// Typescript provides no way to access
+// keys of an interface at runtime.
+export const questionTagNames: QuestionTagName[] = [
+  'CRYPTO',
+  'FOREIGN_ACCOUNT_EXISTS',
+  'FINCEN_114',
+  'FINCEN_114_ACCOUNT_COUNTRY',
+  'FOREIGN_TRUST_RELATIONSHIP'
+]
+
+type ValueTag = 'string' | 'boolean'
 
 export interface Question {
   text: string
   required: Either<boolean, (state: TaxesState) => boolean>
-  tag: QuestionTag
+  tag: QuestionTagName
+  // This is repeated effort, as it has to mirror value type from QuestionTag:
+  readonly valueTag: ValueTag
 }
 
-// function q (tag: QuestionTag, text: string, required: ((s: TaxesState) => boolean)): Question {
-//   return { text, tag, required: right(required) }
-// }
+export type Responses = Partial<QuestionTag>
 
-function qr (tag: QuestionTag, text: string): Question {
-  return { text, tag, required: left(true) }
+function q (tag: QuestionTagName, text: string, valueTag: ValueTag, required: ((s: TaxesState) => boolean)): Question {
+  return { text, tag, required: right(required), valueTag }
+}
+
+function qr (tag: QuestionTagName, text: string, valueTag: ValueTag = 'boolean'): Question {
+  return { text, tag, required: left(true), valueTag }
 }
 
 export const questions: Question[] = [
-  qr(QuestionTag.CRYPTO, 'Do you have any crypto-currency transactions?')
+  qr(
+    'CRYPTO',
+    'Do you have any crypto-currency transactions?'
+  ),
+  qr(
+    'FOREIGN_ACCOUNT_EXISTS',
+    'At any time in this year, did you have a financial interest in or signature authority over a financial account such as a bank account, securities account, or brokerage account) located in a foreign country?'
+  ),
+  q(
+    'FINCEN_114',
+    'Are you required to file FinCEN Form 114, Report of Foreign Bank and Financial Accounts (FBAR), to report that financial interest or signature authority? See FinCEN Form 114 and its instructions for filing requirements and exceptions to those requirements',
+    'boolean',
+    (s: TaxesState) => s.information.questions.FOREIGN_ACCOUNT_EXISTS ?? false
+  ),
+  q(
+    'FINCEN_114_ACCOUNT_COUNTRY',
+    'Enter the name of the foreign country where the financial account is located',
+    'string',
+    (s: TaxesState) => s.information.questions.FINCEN_114 ?? false
+  ),
+  qr(
+    'FOREIGN_TRUST_RELATIONSHIP',
+    'During this tax year, did you receive a distribution from, or were you the grantor of, or a transferor to, a foreign trust?'
+  )
 ]
 
 export const getRequiredQuestions = (state: TaxesState): Question[] => questions.filter((q) =>

--- a/src/irsForms/F1040.ts
+++ b/src/irsForms/F1040.ts
@@ -20,6 +20,7 @@ import ScheduleB from './ScheduleB'
 import { computeOrdinaryTax } from './TaxTable'
 import SDQualifiedAndCapGains from './worksheets/SDQualifiedAndCapGains'
 import F4797 from './F4797'
+import { QuestionTag } from '../data/questions'
 
 export enum F1040Error {
   filingStatusUndefined = 'Select a filing status'
@@ -97,6 +98,10 @@ export default class F1040 implements Form {
 
   addW2 (w2: IncomeW2): void {
     this.w2s.push(w2)
+  }
+
+  addQuestions (questions: { [k in keyof typeof QuestionTag]?: boolean }): void {
+    this.virtualCurrency = questions.CRYPTO ?? false
   }
 
   addSchedule1 (s: Schedule1): void {

--- a/src/irsForms/F1040.ts
+++ b/src/irsForms/F1040.ts
@@ -20,7 +20,7 @@ import ScheduleB from './ScheduleB'
 import { computeOrdinaryTax } from './TaxTable'
 import SDQualifiedAndCapGains from './worksheets/SDQualifiedAndCapGains'
 import F4797 from './F4797'
-import { QuestionTag } from '../data/questions'
+import { Responses } from '../data/questions'
 
 export enum F1040Error {
   filingStatusUndefined = 'Select a filing status'
@@ -100,7 +100,7 @@ export default class F1040 implements Form {
     this.w2s.push(w2)
   }
 
-  addQuestions (questions: { [k in keyof typeof QuestionTag]?: boolean }): void {
+  addQuestions (questions: Responses): void {
     this.virtualCurrency = questions.CRYPTO ?? false
   }
 

--- a/src/irsForms/Main.ts
+++ b/src/irsForms/Main.ts
@@ -58,6 +58,8 @@ export function create1040 (state: Information): Either<F1040Error[], [F1040, Fo
 
   state.w2s.forEach((w2) => f1040.addW2(w2))
 
+  f1040.addQuestions(state.questions)
+
   if (state.refund !== undefined) {
     f1040.addRefund(state.refund)
   }

--- a/src/irsForms/ScheduleB.ts
+++ b/src/irsForms/ScheduleB.ts
@@ -70,14 +70,19 @@ export default class ScheduleB implements Form {
     sumFields(this.l5Fields().map(({ amount }) => amount))
   )
 
+  foreignAccount = (): boolean => this.state.questions.FOREIGN_ACCOUNT_EXISTS ?? false
+  fincenForm = (): boolean => this.state.questions.FINCEN_114 ?? false
+  fincenCountry = (): string | undefined => this.state.questions.FINCEN_114_ACCOUNT_COUNTRY
+  foreignTrust = (): boolean => this.state.questions.FOREIGN_TRUST_RELATIONSHIP ?? false
+
   // TODO - FINCEN questions
-  l7a = (): [boolean, boolean] => [false, false]
+  l7a = (): [boolean, boolean] => [this.foreignAccount(), !this.foreignAccount()]
 
-  l7a2 = (): [boolean, boolean] => [false, false]
+  l7a2 = (): [boolean, boolean] => [this.fincenForm(), !this.fincenForm()]
 
-  l7b = (): string | undefined => undefined
+  l7b = (): string | undefined => this.fincenCountry()
 
-  l8 = (): [boolean, boolean] => [false, false]
+  l8 = (): [boolean, boolean] => [this.foreignTrust(), !this.foreignTrust()]
 
   fields = (): Array<string | number | boolean | undefined> => {
     const tp = new TaxPayer(this.state.taxPayer)

--- a/src/irsForms/ScheduleB.ts
+++ b/src/irsForms/ScheduleB.ts
@@ -75,7 +75,6 @@ export default class ScheduleB implements Form {
   fincenCountry = (): string | undefined => this.state.questions.FINCEN_114_ACCOUNT_COUNTRY
   foreignTrust = (): boolean => this.state.questions.FOREIGN_TRUST_RELATIONSHIP ?? false
 
-  // TODO - FINCEN questions
   l7a = (): [boolean, boolean] => [this.foreignAccount(), !this.foreignAccount()]
 
   l7a2 = (): [boolean, boolean] => [this.fincenForm(), !this.fincenForm()]

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -13,7 +13,8 @@ import {
   Property,
   Edit1099Action,
   EditW2Action,
-  TaxesState
+  TaxesState,
+  AnswerQuestionAction
 } from './data'
 import { ValidateFunction } from 'ajv'
 import ajv,
@@ -38,6 +39,7 @@ export enum ActionName {
   ADD_PROPERTY = 'ADD_PROPERTY',
   EDIT_PROPERTY = 'EDIT_PROPERTY',
   REMOVE_PROPERTY = 'REMOVE_PROPERTY',
+  ANSWER_QUESTION = 'ANSWER_QUESTION',
   SET_ENTIRE_STATE = 'SET_ENTIRE_STATE'
 }
 
@@ -64,6 +66,7 @@ type Remove1099 = Save<typeof ActionName.REMOVE_1099, number>
 type AddProperty = Save<typeof ActionName.ADD_PROPERTY, Property>
 type EditProperty = Save<typeof ActionName.EDIT_PROPERTY, EditPropertyAction>
 type RemoveProperty = Save<typeof ActionName.REMOVE_PROPERTY, number>
+type AnswerQuestion = Save<typeof ActionName.ANSWER_QUESTION, AnswerQuestionAction>
 type SetEntireState = Save<typeof ActionName.SET_ENTIRE_STATE, TaxesState>
 
 export type Actions =
@@ -85,6 +88,7 @@ export type Actions =
   | AddProperty
   | EditProperty
   | RemoveProperty
+  | AnswerQuestion
   | SetEntireState
 
 export type ActionCreator<A> = (formData: A) => Actions
@@ -233,6 +237,11 @@ export const editProperty: ActionCreator<EditPropertyAction> = makeActionCreator
 export const removeProperty: ActionCreator<number> = makeActionCreator(
   ActionName.REMOVE_PROPERTY,
   ajv.compile(indexSchema)
+)
+
+export const answerQuestion: ActionCreator<AnswerQuestionAction> = makeActionCreator(
+  ActionName.ANSWER_QUESTION,
+  ajv.getSchema('#/definitions/AnswerQuestionAction') as ValidateFunction<AnswerQuestionAction>
 )
 
 // debugging purposes only, leaving unchecked.

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -13,12 +13,12 @@ import {
   Property,
   Edit1099Action,
   EditW2Action,
-  TaxesState,
-  AnswerQuestionAction
+  TaxesState
 } from './data'
 import { ValidateFunction } from 'ajv'
 import ajv,
 { checkType } from './validate'
+import { Responses } from '../data/questions'
 
 export enum ActionName {
   SAVE_REFUND_INFO = 'SAVE_REFUND_INFO',
@@ -66,7 +66,7 @@ type Remove1099 = Save<typeof ActionName.REMOVE_1099, number>
 type AddProperty = Save<typeof ActionName.ADD_PROPERTY, Property>
 type EditProperty = Save<typeof ActionName.EDIT_PROPERTY, EditPropertyAction>
 type RemoveProperty = Save<typeof ActionName.REMOVE_PROPERTY, number>
-type AnswerQuestion = Save<typeof ActionName.ANSWER_QUESTION, AnswerQuestionAction>
+type AnswerQuestion = Save<typeof ActionName.ANSWER_QUESTION, Responses>
 type SetEntireState = Save<typeof ActionName.SET_ENTIRE_STATE, TaxesState>
 
 export type Actions =
@@ -104,7 +104,7 @@ function signalAction<T extends ActionName> (t: T): Save<T, {}> {
   *  Create an action constructor given an action name and a validator
   *  for the action's payload. The validator checks the payload against
   *  the schema at runtime so we can see errors if data of the wrong types
-  *  about to be inserted into the
+  *  about to be inserted into the model
   */
 function makeActionCreator<A extends Object, T extends ActionName> (
   t: T,
@@ -239,9 +239,9 @@ export const removeProperty: ActionCreator<number> = makeActionCreator(
   ajv.compile(indexSchema)
 )
 
-export const answerQuestion: ActionCreator<AnswerQuestionAction> = makeActionCreator(
+export const answerQuestion: ActionCreator<Responses> = makeActionCreator(
   ActionName.ANSWER_QUESTION,
-  ajv.getSchema('#/definitions/AnswerQuestionAction') as ValidateFunction<AnswerQuestionAction>
+  ajv.getSchema('#/definitions/Responses') as ValidateFunction<Responses>
 )
 
 // debugging purposes only, leaving unchecked.

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1,3 +1,5 @@
+import { QuestionTag } from '../data/questions'
+
 export enum PersonRole {
   PRIMARY = 'PRIMARY',
   SPOUSE = 'SPOUSE',
@@ -201,12 +203,15 @@ export interface Property {
   otherExpenseType?: string
 }
 
+export type QuestionResponses = {[k in keyof typeof QuestionTag]?: boolean}
+
 export interface Information {
   f1099s: Supported1099[]
   w2s: IncomeW2[]
   realEstate: Property[]
   refund?: Refund
   taxPayer: TaxPayer
+  questions: QuestionResponses
 }
 
 export interface TaxesState {
@@ -216,6 +221,11 @@ export interface TaxesState {
 export interface ArrayItemEditAction<A> {
   index: number
   value: A
+}
+
+export interface AnswerQuestionAction {
+  tag: keyof typeof QuestionTag
+  value: boolean
 }
 
 export type EditDependentAction = ArrayItemEditAction<Dependent>

--- a/src/redux/data.ts
+++ b/src/redux/data.ts
@@ -1,4 +1,4 @@
-import { QuestionTag } from '../data/questions'
+import { Responses } from '../data/questions'
 
 export enum PersonRole {
   PRIMARY = 'PRIMARY',
@@ -203,15 +203,13 @@ export interface Property {
   otherExpenseType?: string
 }
 
-export type QuestionResponses = {[k in keyof typeof QuestionTag]?: boolean}
-
 export interface Information {
   f1099s: Supported1099[]
   w2s: IncomeW2[]
   realEstate: Property[]
   refund?: Refund
   taxPayer: TaxPayer
-  questions: QuestionResponses
+  questions: Responses
 }
 
 export interface TaxesState {
@@ -221,11 +219,6 @@ export interface TaxesState {
 export interface ArrayItemEditAction<A> {
   index: number
   value: A
-}
-
-export interface AnswerQuestionAction {
-  tag: keyof typeof QuestionTag
-  value: boolean
 }
 
 export type EditDependentAction = ArrayItemEditAction<Dependent>

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -201,13 +201,10 @@ function formReducer (state: Information | undefined, action: Actions): Informat
       }
     }
     case ActionName.ANSWER_QUESTION: {
-      const newQuestions = {
-        ...newState.questions,
-        ...action.formData
-      }
+      // must reset all questions
       return {
         ...newState,
-        questions: newQuestions
+        questions: action.formData
       }
     }
     case ActionName.SET_ENTIRE_STATE: {

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -10,7 +10,8 @@ export const blankState: Information = {
   f1099s: [],
   w2s: [],
   realEstate: [],
-  taxPayer: { dependents: [] }
+  taxPayer: { dependents: [] },
+  questions: {}
 }
 
 function formReducer (state: Information | undefined, action: Actions): Information {
@@ -197,6 +198,16 @@ function formReducer (state: Information | undefined, action: Actions): Informat
       return {
         ...newState,
         realEstate: newProperties
+      }
+    }
+    case ActionName.ANSWER_QUESTION: {
+      const newQuestions = {
+        ...newState.questions,
+        [action.formData.tag]: action.formData.value
+      }
+      return {
+        ...newState,
+        questions: newQuestions
       }
     }
     case ActionName.SET_ENTIRE_STATE: {

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -203,7 +203,7 @@ function formReducer (state: Information | undefined, action: Actions): Informat
     case ActionName.ANSWER_QUESTION: {
       const newQuestions = {
         ...newState.questions,
-        [action.formData.tag]: action.formData.value
+        ...action.formData
       }
       return {
         ...newState,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware } from 'redux'
+import { createStore as reduxCreateStore, applyMiddleware, Store } from 'redux'
 import logger from 'redux-logger'
 import rootReducer, { blankState } from './reducer'
 
@@ -6,6 +6,7 @@ import { persistStore, persistReducer, createTransform } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
 import { Information } from './data'
 import { Actions } from './actions'
+import { PersistPartial } from 'redux-persist/es/persistReducer'
 
 const baseTransform = createTransform(
   // transform state on its way to being serialized and persisted.
@@ -31,6 +32,11 @@ const persistConfig = {
 
 const persistedReducer = persistReducer<{information: Information}, Actions>(persistConfig, rootReducer)
 
-export const store = createStore(persistedReducer, applyMiddleware(logger))
+export type InfoStore = Store<{ information: Information }> & { dispatch: {}}
+export type PersistedStore = Store<{ information: Information } & PersistPartial, Actions> & { dispatch: {}}
+
+export const createStoreUnpersisted = (information: Information): InfoStore => reduxCreateStore(rootReducer, { information }, undefined)
+export const createStore = (): PersistedStore => reduxCreateStore(persistedReducer, applyMiddleware(logger))
+export const store = createStore()
 
 export const persistor = persistStore(store)

--- a/src/redux/validate.ts
+++ b/src/redux/validate.ts
@@ -54,5 +54,6 @@ ajv.getSchema('#/definitions/Property')
 ajv.getSchema('#/definitions/PropertyType')
 ajv.getSchema('#/definitions/EditPropertyAction')
 ajv.getSchema('#/definitions/TaxesState')
+ajv.getSchema('#/definitions/AnswerQuestionAction')
 
 export default ajv

--- a/src/redux/validate.ts
+++ b/src/redux/validate.ts
@@ -54,6 +54,6 @@ ajv.getSchema('#/definitions/Property')
 ajv.getSchema('#/definitions/PropertyType')
 ajv.getSchema('#/definitions/EditPropertyAction')
 ajv.getSchema('#/definitions/TaxesState')
-ajv.getSchema('#/definitions/AnswerQuestionAction')
+ajv.getSchema('#/definitions/Responses')
 
 export default ajv

--- a/src/tests/arbitraries.ts
+++ b/src/tests/arbitraries.ts
@@ -1,6 +1,7 @@
 import fc, { Arbitrary } from 'fast-check'
 import { CURRENT_YEAR } from '../data/federal'
 import locationPostalCodes from '../data/locationPostalCodes'
+import { QuestionTag } from '../data/questions'
 import F1040 from '../irsForms/F1040'
 import Form from '../irsForms/Form'
 import { create1040 } from '../irsForms/Main'
@@ -188,10 +189,16 @@ export const taxPayer: Arbitrary<types.TaxPayer> =
       filingStatus, primaryPerson, spouse, dependents, contactEmail, contactPhoneNumber
     }))
 
+const questionTag: Arbitrary<keyof typeof QuestionTag> =
+  fc.constantFrom(...util.enumKeys(QuestionTag))
+
+export const questions: Arbitrary<types.QuestionResponses> =
+  fc.set(questionTag).map((tags) => Object.fromEntries(tags.map((t) => [t, true])))
+
 export const information: Arbitrary<types.Information> =
-  fc.tuple(fc.array(f1099), fc.array(w2), fc.array(property), refund, taxPayer)
-    .map(([f1099s, w2s, realEstate, refund, taxPayer]) => ({
-      f1099s, w2s, realEstate, refund, taxPayer
+  fc.tuple(fc.array(f1099), fc.array(w2), fc.array(property), refund, taxPayer, questions)
+    .map(([f1099s, w2s, realEstate, refund, taxPayer, questions]) => ({
+      f1099s, w2s, realEstate, refund, taxPayer, questions
     }))
 
 export const taxesState: Arbitrary<types.TaxesState> =

--- a/src/tests/arbitraries.ts
+++ b/src/tests/arbitraries.ts
@@ -1,7 +1,7 @@
 import fc, { Arbitrary } from 'fast-check'
 import { CURRENT_YEAR } from '../data/federal'
 import locationPostalCodes from '../data/locationPostalCodes'
-import { QuestionTag } from '../data/questions'
+import { QuestionTagName, questionTagNames, Responses } from '../data/questions'
 import F1040 from '../irsForms/F1040'
 import Form from '../irsForms/Form'
 import { create1040 } from '../irsForms/Main'
@@ -189,10 +189,10 @@ export const taxPayer: Arbitrary<types.TaxPayer> =
       filingStatus, primaryPerson, spouse, dependents, contactEmail, contactPhoneNumber
     }))
 
-const questionTag: Arbitrary<keyof typeof QuestionTag> =
-  fc.constantFrom(...util.enumKeys(QuestionTag))
+const questionTag: Arbitrary<QuestionTagName> =
+  fc.constantFrom(...questionTagNames)
 
-export const questions: Arbitrary<types.QuestionResponses> =
+export const questions: Arbitrary<Responses> =
   fc.set(questionTag).map((tags) => Object.fromEntries(tags.map((t) => [t, true])))
 
 export const information: Arbitrary<types.Information> =

--- a/src/tests/componets/Questions.test.tsx
+++ b/src/tests/componets/Questions.test.tsx
@@ -1,0 +1,87 @@
+import React, { ReactElement } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import Questions from '../../components/Questions'
+import { InfoStore, createStoreUnpersisted } from '../../redux/store'
+import { questions, QuestionTag } from '../../data/questions'
+import { create1040 } from '../../irsForms/Main'
+import { isRight } from '../../util'
+import * as fc from 'fast-check'
+import * as arbitraries from '../arbitraries'
+import { PagerButtons, PagerContext } from '../../components/pager'
+import { Information } from '../../redux/data'
+import { blankState } from '../../redux/reducer'
+
+afterEach(async () => {
+  await waitFor(() => localStorage.clear())
+  jest.resetAllMocks()
+})
+
+jest.mock('redux-persist', () => {
+  const real = jest.requireActual('redux-persist')
+  return {
+    ...real,
+    persistReducer: jest.fn().mockImplementation((config, reducers) => reducers)
+  }
+})
+
+describe('Questions', () => {
+  const navButtons = (
+    <PagerButtons
+      submitText="Save"
+    />
+  )
+
+  const testComponent = (info: Information | undefined = blankState): [InfoStore, ReactElement] => {
+    const store = createStoreUnpersisted(info)
+    const component = (
+      <Provider store={store}>
+        <PagerContext.Provider value={{ onAdvance: () => { }, navButtons }}>
+          <Questions />
+        </PagerContext.Provider>
+      </Provider>
+    )
+
+    return [store, component]
+  }
+
+  const cryptoQuestion = questions.find((q) => q.tag === QuestionTag.CRYPTO)
+
+  if (cryptoQuestion === undefined) {
+    throw new Error('crypto question undefined')
+  }
+
+  it('should always show crypto question', async () => {
+    const [, component] = testComponent()
+    const result = render(component)
+    const questionComponent = await result.findAllByText(cryptoQuestion.text)
+    expect(questionComponent[0]).toBeInTheDocument()
+  })
+
+  it('should propagate to model', async () => {
+    const [store, component] = testComponent()
+    const result = render(component)
+    const checkBoxes = await result.findAllByRole('checkbox')
+    const save = await result.findByRole('button', { name: /Save/ })
+    checkBoxes.forEach((b) => fireEvent.click(b))
+    fireEvent.click(save)
+
+    await waitFor(() => { })
+    expect(store.getState().information.questions.CRYPTO).toBeTruthy()
+  })
+
+  it('should propagate to 1040', async () => {
+    return await fc.assert(
+      fc.asyncProperty(arbitraries.information, async (info) => {
+        const f1040 = create1040(info)
+
+        if (isRight(f1040)) {
+          expect(f1040.right[0].virtualCurrency).toEqual(info.questions.CRYPTO ?? false)
+        } else {
+          expect(f1040.left).toEqual([])
+        }
+        return await Promise.resolve(true)
+      })
+    )
+  })
+})

--- a/src/tests/componets/Questions.test.tsx
+++ b/src/tests/componets/Questions.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import Questions from '../../components/Questions'
 import { InfoStore, createStoreUnpersisted } from '../../redux/store'
-import { questions, QuestionTag } from '../../data/questions'
+import { questions } from '../../data/questions'
 import { create1040 } from '../../irsForms/Main'
 import { isRight } from '../../util'
 import * as fc from 'fast-check'
@@ -45,7 +45,7 @@ describe('Questions', () => {
     return [store, component]
   }
 
-  const cryptoQuestion = questions.find((q) => q.tag === QuestionTag.CRYPTO)
+  const cryptoQuestion = questions.find((q) => q.tag === 'CRYPTO')
 
   if (cryptoQuestion === undefined) {
     throw new Error('crypto question undefined')


### PR DESCRIPTION
I added a new Questions component that tries to calculate the minimal set of questions that will need to be answered based on the current state. There is only one question now that always needs to be answered. Next up would be to support the questions from schedule B (#118).