### PR TITLE
Refactor to use FormContext

### DIFF
--- a/src/components/Patterns.ts
+++ b/src/components/Patterns.ts
@@ -1,37 +1,28 @@
-import { Control } from 'react-hook-form'
 import { CURRENT_YEAR } from '../data/federal'
 import { daysInYear } from '../util'
 
-export enum InputType {
-  text = 'text',
-  numeric = 'numeric',
-  preNumeric = 'prenumeric'
-}
-
-export interface PatternConfig<A> {
+export interface BasePattern {
   regexp?: RegExp
-  inputType: A
   description?: string
   format?: string
 }
 
-export interface NumericPattern extends PatternConfig<typeof InputType.numeric> {
+export interface NumericPattern extends BasePattern {
+  readonly inputType: 'numeric'
   thousandSeparator?: boolean
   mask?: string
   prefix?: string
   allowEmptyFormatting?: boolean
   decimalScale?: number
-  control: Control
   min?: number
   max?: number
 }
 
-// Numeric patterns require the control property, which is not available now.
-// This allows us to generate numeric patterns at render time.
-type PreNumeric = (control: Control) => NumericPattern
+export interface TextPattern extends BasePattern {
+  readonly inputType: 'text'
+}
 
-export type TextPattern = PatternConfig<typeof InputType.text>
-export type Pattern = NumericPattern | TextPattern
+export type PatternConfig = NumericPattern | TextPattern
 
 // Convenience record syntax constructor for numeric patterns
 const numeric = (
@@ -44,28 +35,29 @@ const numeric = (
   thousandSeparator: boolean = false,
   prefix: string = '',
   decimalScale: number | undefined = 0
-): PreNumeric =>
-  (control: Control) => ({
-    inputType: InputType.numeric,
-    regexp,
-    description,
-    decimalScale,
-    min,
-    max,
-    format,
-    mask,
-    thousandSeparator,
-    prefix,
-    control
-  })
+): NumericPattern => ({
+  inputType: 'numeric',
+  regexp,
+  description,
+  decimalScale,
+  min,
+  max,
+  format,
+  mask,
+  thousandSeparator,
+  prefix
+})
 
 const text = (regexp: RegExp, description: string): TextPattern => ({
-  inputType: InputType.text,
+  inputType: 'text',
   regexp,
   description
 })
 
 const numDaysInYear = daysInYear(CURRENT_YEAR)
+
+export const isNumeric = (p: PatternConfig): p is NumericPattern => p.inputType === 'numeric'
+export const isText = (p: PatternConfig): p is TextPattern => p.inputType === 'text'
 
 export const Patterns = {
   year: numeric(/[12][0-9]{3}/, 'Input should be a four digit year', 1900, CURRENT_YEAR, '####', '_'),
@@ -78,5 +70,6 @@ export const Patterns = {
   currency: numeric(/[0-9]+(\.[0-9]{1,2})?/, 'Input should be a numeric value', undefined, undefined, undefined, '_', true, '$', 2),
   bankAccount: numeric(/[0-9]{4,17}/, 'Input should be filled with 4-17 digits', undefined, undefined, '#################', ''),
   bankRouting: numeric(/[0-9]{9}/, 'Input should be filled with 9 digits', undefined, undefined, '#########', '_'),
-  usPhoneNumber: numeric(/[2-9][0-9]{9}/, 'Input should be 10 digits, not starting with 0 or 1', undefined, undefined, '(###)-###-####')
+  usPhoneNumber: numeric(/[2-9][0-9]{9}/, 'Input should be 10 digits, not starting with 0 or 1', undefined, undefined, '(###)-###-####'),
+  plain: text(/.*/, '')
 }

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -5,13 +5,14 @@ import { getRequiredQuestions, QuestionTagName, Responses } from '../data/questi
 import { TaxesState } from '../redux/data'
 import { answerQuestion } from '../redux/actions'
 import { LabeledCheckbox, LabeledInput } from './input'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { PagerContext } from './pager'
 
 const Questions = (): ReactElement => {
   const state = useSelector((state: TaxesState) => state)
 
-  const { control, register, handleSubmit, watch } = useForm<Responses>()
+  const methods = useForm<Responses>()
+  const { handleSubmit, watch } = methods
 
   const currentValues = watch()
 
@@ -41,7 +42,7 @@ const Questions = (): ReactElement => {
     onAdvance()
   }
 
-  return (
+  const page = (
     <PagerContext.Consumer>
       { ({ onAdvance, navButtons }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
@@ -58,7 +59,6 @@ const Questions = (): ReactElement => {
                           <LabeledCheckbox
                             name={q.tag}
                             label={q.text}
-                            control={control}
                             defaultValue={state.information.questions[q.tag] as (boolean | undefined)}
                           />
                         )
@@ -67,7 +67,6 @@ const Questions = (): ReactElement => {
                         return (
                           <LabeledInput
                             name={q.tag}
-                            register={register}
                             label={q.text}
                             defaultValue={state.information.questions[q.tag] as (string | undefined)}
                           />
@@ -83,6 +82,10 @@ const Questions = (): ReactElement => {
         </form>
       }
     </PagerContext.Consumer>
+  )
+
+  return (
+    <FormProvider {...methods}>{page}</FormProvider>
   )
 }
 

--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { LabeledInput, LabeledRadio } from './input'
 import { Patterns } from './Patterns'
@@ -17,7 +17,8 @@ interface UserRefundForm {
 const toRefund = (formData: UserRefundForm): Refund => formData
 
 export default function RefundBankAccount (): ReactElement {
-  const { register, handleSubmit, errors, control } = useForm<UserRefundForm>()
+  const methods = useForm<UserRefundForm>()
+  const { handleSubmit, errors } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -35,14 +36,13 @@ export default function RefundBankAccount (): ReactElement {
     <PagerContext.Consumer>
       { ({ onAdvance, navButtons }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
-          <div>
+          <FormProvider {...methods}>
             <h2>Refund Information</h2>
 
             <LabeledInput
               label="Bank Routing number"
-              register={register}
               required={true}
-              patternConfig={Patterns.bankRouting(control)}
+              patternConfig={Patterns.bankRouting}
               name="routingNumber"
               defaultValue={prevFormData?.routingNumber}
               error={errors.routingNumber}
@@ -50,22 +50,20 @@ export default function RefundBankAccount (): ReactElement {
 
             <LabeledInput
               label="Bank Account number"
-              register={register}
               required={true}
-              patternConfig={Patterns.bankAccount(control)}
+              patternConfig={Patterns.bankAccount}
               name="accountNumber"
               defaultValue={prevFormData?.accountNumber}
               error={errors.accountNumber}
             />
             <LabeledRadio
               label="Account Type"
-              control={control}
               name="accountType"
               defaultValue={prevFormData?.accountType as string}
               values={[['Checking', 'checking'], ['Savings', 'savings']]}
             />
             {navButtons}
-          </div>
+          </FormProvider>
         </form>
       }
     </PagerContext.Consumer>

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,14 +1,11 @@
 import React, { Fragment, ReactElement } from 'react'
-import { Control } from 'react-hook-form'
 import { Address } from '../../redux/data'
 import { LabeledCheckbox, LabeledInput, USStateDropDown } from '../input'
 import { Patterns } from '../Patterns'
-import { Register, Errors } from '../types'
+import { Errors } from '../types'
 
 interface AddressProps {
-  register: Register
   checkboxText: string
-  control: Control
   address?: Address
   errors?: Errors<Address>
   isForeignCountry?: boolean
@@ -17,9 +14,7 @@ interface AddressProps {
 
 export default function AddressFields (props: AddressProps): ReactElement {
   const {
-    register,
     isForeignCountry = false,
-    control,
     address,
     errors,
     checkboxText = 'Check if you have a foreign address',
@@ -33,17 +28,15 @@ export default function AddressFields (props: AddressProps): ReactElement {
           <USStateDropDown
             label="State"
             name="address.state"
-            control={control}
             error={errors?.state}
             required={!isForeignCountry}
             defaultValue={address?.state}
           />
           <LabeledInput
             label="Zip"
-            register={register}
             error={errors?.zip}
             name="address.zip"
-            patternConfig={Patterns.zip(control)}
+            patternConfig={Patterns.zip}
             required={!isForeignCountry}
             defaultValue={address?.zip}
           />
@@ -55,7 +48,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
         <LabeledInput
           label="Province"
           name="address.province"
-          register={register}
           error={errors?.province}
           required={isForeignCountry}
           defaultValue={address?.province}
@@ -63,7 +55,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
         <LabeledInput
           name="address.postalCode"
           label="Postal Code"
-          register={register}
           error={errors?.postalCode}
           required={isForeignCountry}
           defaultValue={address?.postalCode}
@@ -71,7 +62,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
         <LabeledInput
           name="address.foreignCountry"
           label="Country"
-          register={register}
           error={errors?.foreignCountry}
           required={isForeignCountry}
           defaultValue={address?.foreignCountry}
@@ -85,14 +75,12 @@ export default function AddressFields (props: AddressProps): ReactElement {
       <LabeledInput
         label="Address"
         name="address.address"
-        register={register}
         required={true}
         error={errors?.address}
         defaultValue={address?.address}
       />
       <LabeledInput
         label="Unit No"
-        register={register}
         name="address.aptNo"
         required={false}
         error={errors?.aptNo}
@@ -100,7 +88,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
       />
       <LabeledInput
         label="City"
-        register={register}
         name="address.city"
         patternConfig={Patterns.name}
         required={true}
@@ -112,7 +99,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
           return (
             <LabeledCheckbox
               label={checkboxText}
-              control={control}
               name="isForeignCountry"
               defaultValue={isForeignCountry}
             />

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { LabeledInput } from '../input'
 import { Patterns } from '../Patterns'
@@ -8,7 +8,8 @@ import { ContactInfo as Contact, TaxesState, TaxPayer } from '../../redux/data'
 import { PagerContext } from '../pager'
 
 export default function ContactInfo (): ReactElement {
-  const { register, handleSubmit, errors, control } = useForm<Contact>()
+  const methods = useForm<Contact>()
+  const { handleSubmit, errors } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -21,23 +22,21 @@ export default function ContactInfo (): ReactElement {
     onAdvance()
   }
 
-  return (
+  const page = (
     <PagerContext.Consumer>
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
           <h2>Family Contact Information</h2>
           <LabeledInput
             label="Contact phone number"
-            register={register}
             required={true}
-            patternConfig={Patterns.usPhoneNumber(control)}
+            patternConfig={Patterns.usPhoneNumber}
             name="contactPhoneNumber"
             defaultValue={taxPayer?.contactPhoneNumber}
             error={errors.contactPhoneNumber}
           />
           <LabeledInput
             label="Contact email address"
-            register={register}
             required={true}
             name="contactEmail"
             defaultValue={taxPayer?.contactEmail}
@@ -48,4 +47,6 @@ export default function ContactInfo (): ReactElement {
       }
     </PagerContext.Consumer>
   )
+
+  return <FormProvider {...methods}>{page}</FormProvider>
 }

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -10,21 +10,19 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
-import { Control, DeepMap, FieldError } from 'react-hook-form'
+import { DeepMap, FieldError } from 'react-hook-form'
 
 interface PersonFieldsProps<T extends Person> extends BaseFormProps {
   defaults?: T
   children?: ReactNode
   errors: DeepMap<Partial<Person>, FieldError>
   person?: Person
-  control: Control
 }
 
-export const PersonFields = <T extends Person>({ register, control, errors, defaults, children, person }: PersonFieldsProps<T>): ReactElement => (
+export const PersonFields = <T extends Person>({ errors, defaults, children, person }: PersonFieldsProps<T>): ReactElement => (
   <div>
     <LabeledInput
       label="First Name and Initial"
-      register={register}
       name="firstName"
       patternConfig={Patterns.name}
       required={true}
@@ -33,7 +31,6 @@ export const PersonFields = <T extends Person>({ register, control, errors, defa
     />
     <LabeledInput
       label="Last Name"
-      register={register}
       name="lastName"
       patternConfig={Patterns.name}
       required={true}
@@ -42,9 +39,8 @@ export const PersonFields = <T extends Person>({ register, control, errors, defa
     />
     <LabeledInput
       label="SSN / TIN"
-      register={register}
       name="ssid"
-      patternConfig={Patterns.ssn(control)}
+      patternConfig={Patterns.ssn}
       required={true}
       error={errors.ssid}
       defaultValue={person?.ssid ?? defaults?.ssid}

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react'
 
-import { useForm } from 'react-hook-form'
+import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { Patterns } from '../Patterns'
 import { LabeledInput, LabeledCheckbox, formatSSID, GenericLabeledDropdown } from '../input'
@@ -59,7 +59,8 @@ const toSpouse = (formData: UserSpouseForm): Spouse => ({
 })
 
 export const AddDependentForm = (): ReactElement => {
-  const { register, errors, handleSubmit, control, reset } = useForm<UserDependentForm>()
+  const methods = useForm<UserDependentForm>()
+  const { errors, handleSubmit, reset } = methods
 
   const dependents = useSelector((state: TaxesState) =>
     state.information.taxPayer?.dependents ?? []
@@ -89,7 +90,7 @@ export const AddDependentForm = (): ReactElement => {
     setEditingIdx(undefined)
   }
 
-  return (
+  const page = (
     <FormListContainer
       onDone={(onSuccess) => handleSubmit(_onSubmit(onSuccess))}
       onCancel={clear}
@@ -102,14 +103,11 @@ export const AddDependentForm = (): ReactElement => {
       removeItem={(i) => dispatch(removeDependent(i))}
     >
       <PersonFields
-        register={register}
         errors={errors}
-        control={control}
         defaults={defaultValues !== undefined ? toDependent(defaultValues) : undefined}
       />
       <LabeledInput
         label="Relationship to Taxpayer"
-        register={register}
         name="relationship"
         required={true}
         patternConfig={Patterns.name}
@@ -117,18 +115,16 @@ export const AddDependentForm = (): ReactElement => {
         defaultValue={defaultValues?.relationship}
       />
       <LabeledInput
-        register={register}
         label="Birth Year"
-        patternConfig={Patterns.year(control)}
+        patternConfig={Patterns.year}
         name="birthYear"
         required={true}
         error={errors.birthYear}
         defaultValue={defaultValues?.birthYear}
       />
       <LabeledInput
-        register={register}
         label="How many months did you live together this year?"
-        patternConfig={Patterns.numMonths(control)}
+        patternConfig={Patterns.numMonths}
         name="numberOfMonths"
         required={true}
         error={errors.numberOfMonths}
@@ -137,15 +133,17 @@ export const AddDependentForm = (): ReactElement => {
       <LabeledCheckbox
         label="Is this person a full-time student?"
         name="isStudent"
-        control={control}
         defaultValue={defaultValues?.isStudent ?? false}
       />
     </FormListContainer>
   )
+
+  return <FormProvider {...methods}>{page}</FormProvider>
 }
 
 export const SpouseInfo = (): ReactElement => {
-  const { register, control, errors, handleSubmit, getValues } = useForm<UserSpouseForm>()
+  const methods = useForm<UserSpouseForm>()
+  const { errors, handleSubmit, getValues } = methods
   const [editSpouse, setEditSpouse] = useState<boolean>(false)
   const dispatch = useDispatch()
 
@@ -163,7 +161,7 @@ export const SpouseInfo = (): ReactElement => {
     onSuccess()
   }
 
-  return (
+  const page = (
     <FormListContainer
       items={spouse !== undefined ? [spouse] : []}
       primary={(s) => `${s.firstName} ${s.lastName}`}
@@ -177,24 +175,24 @@ export const SpouseInfo = (): ReactElement => {
       removeItem={() => dispatch(removeSpouse)}
     >
       <PersonFields
-        register={register}
         errors={errors}
         person={spouse}
-        control={control}
       >
         <LabeledCheckbox
           label="Check if your spouse is a dependent"
-          control={control}
-          defaultValue={spouse?.isTaxpayerDependent ?? false}
+            defaultValue={spouse?.isTaxpayerDependent ?? false}
           name="isTaxpayerDependent"
         />
       </PersonFields>
     </FormListContainer>
   )
+
+  return <FormProvider {...methods}>{page}</FormProvider>
 }
 
 const SpouseAndDependent = (): ReactElement => {
-  const { handleSubmit, errors, control } = useForm<{filingStatus: FilingStatus}>()
+  const methods = useForm<{ filingStatus: FilingStatus }>()
+  const { handleSubmit, errors } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -206,7 +204,8 @@ const SpouseAndDependent = (): ReactElement => {
     dispatch(saveFilingStatusInfo(formData.filingStatus))
     onAdvance()
   }
-  return (
+
+  const page = (
     <PagerContext.Consumer>
       { ({ onAdvance, navButtons }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
@@ -227,8 +226,7 @@ const SpouseAndDependent = (): ReactElement => {
             error={errors.filingStatus}
             textMapping={status => FilingStatusTexts[status]}
             required={true}
-            control={control}
-            name="filingStatus"
+                name="filingStatus"
             defaultValue={taxPayer?.filingStatus}
           />
           {navButtons}
@@ -236,6 +234,8 @@ const SpouseAndDependent = (): ReactElement => {
       }
     </PagerContext.Consumer>
   )
+
+  return <FormProvider {...methods}>{page}</FormProvider>
 }
 
 export default SpouseAndDependent

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { savePrimaryPersonInfo } from '../../redux/actions'
 import { Address, PersonRole, PrimaryPerson, TaxesState, TaxPayer } from '../../redux/data'
@@ -27,7 +27,8 @@ const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
 })
 
 export default function PrimaryTaxpayer (): ReactElement {
-  const { register, handleSubmit, control, errors } = useForm<PrimaryPerson>()
+  const methods = useForm<PrimaryPerson>()
+  const { handleSubmit, control, formState: { errors } } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -46,26 +47,21 @@ export default function PrimaryTaxpayer (): ReactElement {
     onAdvance()
   }
 
-  return (
+  const page = (
     <PagerContext.Consumer>
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
           <h2>Primary Taxpayer Information</h2>
           <PersonFields
-            register={register}
             errors={errors}
             defaults={taxPayer?.primaryPerson}
-            control={control}
           />
           <LabeledCheckbox
             label="Check if you are a dependent"
-            control={control}
             defaultValue={taxPayer?.primaryPerson?.isTaxpayerDependent ?? false}
             name="isTaxpayerDependent"
           />
           <AddressFields
-            register={register}
-            control={control}
             errors={errors.address}
             address={taxPayer?.primaryPerson?.address}
             checkboxText="Do you have a foreign address?"
@@ -76,4 +72,6 @@ export default function PrimaryTaxpayer (): ReactElement {
       }
     </PagerContext.Consumer>
   )
+
+  return <FormProvider {...methods}>{page}</FormProvider>
 }

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import SchoolIcon from '@material-ui/icons/School'
 import { useDispatch, useSelector } from 'react-redux'
 import { add1098e, edit1098e, remove1098e } from '../../redux/actions'
@@ -49,7 +49,8 @@ export default function F1098eInfo (): ReactElement {
     return blankUserInput
   })()
 
-  const { register, errors, handleSubmit, control, reset } = useForm<F1098EUserInput>()
+  const methods = useForm<F1098EUserInput>()
+  const { errors, handleSubmit, reset } = methods
 
   const dispatch = useDispatch()
 
@@ -89,7 +90,6 @@ export default function F1098eInfo (): ReactElement {
 
     <LabeledInput
       label="Enter name of Lender"
-      register={register}
       required={true}
       patternConfig={Patterns.name}
       name="lender"
@@ -99,9 +99,8 @@ export default function F1098eInfo (): ReactElement {
 
     <LabeledInput
         label="Student Interest Paid"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="interest"
         error={errors.interest}
         defaultValue={defaultValues?.interest.toString()}
@@ -114,9 +113,11 @@ export default function F1098eInfo (): ReactElement {
     <PagerContext.Consumer>
       { ({ onAdvance, navButtons }) =>
         <form onSubmit={onAdvance}>
-          <h2>1098-E Information</h2>
-            {form}
-            { navButtons }
+          <FormProvider {...methods}>
+            <h2>1098-E Information</h2>
+              {form}
+            {navButtons}
+          </FormProvider>
         </form>
       }
     </PagerContext.Consumer>

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, FormProvider } from 'react-hook-form'
 import { Icon } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import { add1099, edit1099, remove1099 } from '../../redux/actions'
@@ -136,7 +136,8 @@ export default function F1099Info (): ReactElement {
     return blankUserInput
   })()
 
-  const { register, errors, handleSubmit, control, reset, watch, setValue } = useForm<F1099UserInput>()
+  const methods = useForm<F1099UserInput>()
+  const { errors, handleSubmit, reset, watch, setValue } = methods
   const selectedType: Income1099Type | undefined = watch('formType')
 
   const dispatch = useDispatch()
@@ -172,9 +173,8 @@ export default function F1099Info (): ReactElement {
   const intFields = (
     <LabeledInput
       label="Box 1 - Interest Income"
-      register={register}
       required={true}
-      patternConfig={Patterns.currency(control)}
+      patternConfig={Patterns.currency}
       name="interest"
       error={errors.interest}
       defaultValue={defaultValues?.interest.toString()}
@@ -186,18 +186,16 @@ export default function F1099Info (): ReactElement {
       <h4>Long Term Covered Transactions</h4>
       <LabeledInput
         label="Proceeds"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="longTermProceeds"
         error={errors.longTermProceeds}
         defaultValue={defaultValues?.longTermProceeds.toString()}
       />
       <LabeledInput
         label="Cost basis"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="longTermCostBasis"
         error={errors.longTermCostBasis}
         defaultValue={defaultValues?.longTermCostBasis.toString()}
@@ -205,18 +203,16 @@ export default function F1099Info (): ReactElement {
       <h4>Short Term Covered Transactions</h4>
       <LabeledInput
         label="Proceeds"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="shortTermProceeds"
         error={errors.shortTermProceeds}
         defaultValue={defaultValues?.shortTermProceeds.toString()}
       />
       <LabeledInput
         label="Cost basis"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="shortTermCostBasis"
         error={errors.shortTermCostBasis}
         defaultValue={defaultValues?.shortTermCostBasis.toString()}
@@ -228,18 +224,16 @@ export default function F1099Info (): ReactElement {
     <div>
       <LabeledInput
         label="Total Dividends"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="dividends"
         error={errors.dividends}
         defaultValue={defaultValues?.dividends.toString()}
       />
       <LabeledInput
         label="Qualified Dividends"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="qualifiedDividends"
         error={errors.qualifiedDividends}
         defaultValue={defaultValues?.qualifiedDividends.toString()}
@@ -275,7 +269,6 @@ export default function F1099Info (): ReactElement {
 
       <GenericLabeledDropdown
         dropDownData={Object.values(Income1099Type)}
-        control={control}
         error={errors.formType}
         label="Form Type"
         required={true}
@@ -288,7 +281,6 @@ export default function F1099Info (): ReactElement {
 
       <LabeledInput
         label="Enter name of bank, broker firm, or other payer"
-        register={register}
         required={true}
         patternConfig={Patterns.name}
         name="payer"
@@ -303,7 +295,6 @@ export default function F1099Info (): ReactElement {
 
       <GenericLabeledDropdown
         dropDownData={people}
-        control={control}
         error={errors.personRole}
         label="Recipient"
         required={true}
@@ -321,7 +312,9 @@ export default function F1099Info (): ReactElement {
       { ({ onAdvance, navButtons }) =>
         <form onSubmit={onAdvance}>
           <h2>1099 Information</h2>
-          {form}
+          <FormProvider {...methods}>
+            {form}
+          </FormProvider>
           { navButtons }
         </form>
       }

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, ReactElement, useState } from 'react'
-import { Message, useForm, useWatch } from 'react-hook-form'
+import { Message, useForm, useWatch, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { addProperty, editProperty, removeProperty } from '../../redux/actions'
 import { PagerContext } from '../pager'
@@ -118,7 +118,8 @@ const toUserInput = (property: Property): PropertyAddForm => {
 }
 
 export default function RealEstate (): ReactElement {
-  const { register, control, errors, getValues, handleSubmit, reset } = useForm<PropertyAddForm>()
+  const methods = useForm<PropertyAddForm>()
+  const { control, errors, getValues, handleSubmit, reset } = methods
   const dispatch = useDispatch()
 
   const properties: Property[] = useSelector((state: TaxesState) => state.information.realEstate)
@@ -181,8 +182,7 @@ export default function RealEstate (): ReactElement {
         key={i}
         label={displayExpense(PropertyExpenseType[k])}
         name={`expenses.${k.toString()}`}
-        register={register}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         defaultValue={defaultValues?.expenses[k]?.toString() ?? ''}
       />
     )
@@ -197,7 +197,6 @@ export default function RealEstate (): ReactElement {
           key={enumKeys(PropertyExpenseType).length}
           label="Other description"
           name="otherExpenseType"
-          register={register}
           defaultValue={defaultValues?.otherExpenseType ?? ''}
           required={true}
         />
@@ -218,8 +217,6 @@ export default function RealEstate (): ReactElement {
     >
       <h4>Property location</h4>
       <AddressFields
-        register={register}
-        control={control}
         errors={errors.address}
         checkboxText="Does the property have a foreign address"
         address={defaultValues?.address}
@@ -232,7 +229,6 @@ export default function RealEstate (): ReactElement {
         required={true}
         textMapping={(t) => displayPropertyType(PropertyType[t])}
         keyMapping={(_, n) => n}
-        control={control}
         name="propertyType"
         defaultValue={defaultValues?.propertyType?.toString()}
         valueMapping={(n) => n}
@@ -245,7 +241,6 @@ export default function RealEstate (): ReactElement {
               defaultValue={defaultValues?.otherPropertyType ?? '' }
               label="Short property type description"
               error={errors.otherPropertyType}
-              register={register}
               required={true}
             />
           )
@@ -254,26 +249,23 @@ export default function RealEstate (): ReactElement {
       <h4>Use</h4>
       <LabeledInput
         name="rentalDays"
-        register={register}
         required={true}
         rules={{ validate: (n: String) => validateRental(Number(n)) }}
         label="Number of days in the year used for rental"
-        patternConfig={Patterns.numDays(control)}
+        patternConfig={Patterns.numDays}
         error={errors.rentalDays}
         defaultValue={defaultValues?.rentalDays?.toString()}
       />
       <LabeledInput
         name="personalUseDays"
-        register={register}
         rules={{ validate: (n: String) => validatePersonal(Number(n)) }}
         label="Number of days in the year for personal use"
-        patternConfig={Patterns.numDays(control)}
+        patternConfig={Patterns.numDays}
         error={errors.personalUseDays}
         defaultValue={defaultValues?.personalUseDays?.toString()}
       />
       <LabeledCheckbox
         name="qualifiedJointVenture"
-        control={control}
         label="Is this a qualified joint venture"
         defaultValue={defaultValues?.qualifiedJointVenture ?? false}
       />
@@ -282,8 +274,7 @@ export default function RealEstate (): ReactElement {
       <LabeledInput
         name="rentReceived"
         label="Rent received"
-        register={register}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         error={errors.rentReceived}
         defaultValue={defaultValues?.rentReceived?.toString()}
       />
@@ -315,7 +306,9 @@ export default function RealEstate (): ReactElement {
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={onAdvance}>
           <h2>Properties</h2>
-          {form}
+          <FormProvider {...methods}>
+            {form}
+          </FormProvider>
           { navButtons }
         </form>
       }

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
+import { FormProvider, useForm } from 'react-hook-form'
 import { PagerContext } from '../pager'
 import { TaxesState, IncomeW2, Person, PersonRole } from '../../redux/data'
 import { Currency, formatSSID, GenericLabeledDropdown, LabeledInput } from '../input'
@@ -30,7 +30,8 @@ const toIncomeW2 = (formData: IncomeW2UserInput): IncomeW2 => ({
 })
 
 export default function W2JobInfo (): ReactElement {
-  const { register, errors, handleSubmit, control, reset } = useForm<IncomeW2UserInput>()
+  const methods = useForm<IncomeW2UserInput>()
+  const { errors, handleSubmit, reset } = methods
   const dispatch = useDispatch()
 
   const [editing, setEditing] = useState<number | undefined>(undefined)
@@ -85,7 +86,6 @@ export default function W2JobInfo (): ReactElement {
       <strong>Input data from W-2</strong>
       <LabeledInput
         label="Occupation"
-        register={register}
         required={true}
         name="occupation"
         error={errors.occupation}
@@ -95,9 +95,8 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 1 - "
         label="Wages, tips, other compensation"
-        register={register}
         required={true}
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         name="income"
         error={errors.income}
         defaultValue={defaultValues?.income.toString()}
@@ -106,10 +105,9 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 2 - "
         label="Federal income tax withheld"
-        register={register}
         required={true}
         name="fedWithholding"
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         error={errors.fedWithholding}
         defaultValue={defaultValues?.fedWithholding.toString()}
       />
@@ -117,26 +115,23 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 4 - "
         label="Social security tax withheld"
-        register={register}
         required={true}
         name="ssWithholding"
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         error={errors.ssWithholding}
       />
 
       <LabeledInput
         strongLabel="Box 6 - "
         label="Medicare tax withheld"
-        register={register}
         required={true}
         name="medicareWithholding"
-        patternConfig={Patterns.currency(control)}
+        patternConfig={Patterns.currency}
         error={errors.medicareWithholding}
       />
 
       <GenericLabeledDropdown
         dropDownData={people}
-        control={control}
         error={errors.personRole}
         label="Employee"
         required={true}
@@ -154,7 +149,9 @@ export default function W2JobInfo (): ReactElement {
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={onAdvance}>
           <h2>Job Information</h2>
-          {form}
+          <FormProvider {...methods}>
+            {form}
+          </FormProvider>
           { navButtons }
         </form>
       }

--- a/src/components/input/LabeledCheckbox.tsx
+++ b/src/components/input/LabeledCheckbox.tsx
@@ -1,11 +1,12 @@
 import React, { ReactElement } from 'react'
 import { Checkbox, FormControl, FormControlLabel, FormGroup } from '@material-ui/core'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { LabeledCheckboxProps } from './types'
 import useStyles from './styles'
 
 export function LabeledCheckbox (props: LabeledCheckboxProps): ReactElement {
-  const { label, name, control, defaultValue } = props
+  const { label, name, defaultValue } = props
+  const { control } = useFormContext()
 
   const classes = useStyles()
 

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -1,11 +1,12 @@
 import React, { ReactElement } from 'react'
 import { Box, TextField } from '@material-ui/core'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import locationPostalCodes from '../../data/locationPostalCodes'
 import { BaseDropdownProps, LabeledDropdownProps } from './types'
 
 export function GenericLabeledDropdown<A> (props: LabeledDropdownProps<A>): ReactElement {
-  const { strongLabel, label, dropDownData, valueMapping, error, keyMapping, textMapping, control, required = false, name } = props
+  const { control } = useFormContext()
+  const { strongLabel, label, dropDownData, valueMapping, error, keyMapping, textMapping, required = false, name } = props
   const { defaultValue = '' } = props
 
   return (

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -2,26 +2,30 @@ import React, { ReactElement } from 'react'
 import { TextField } from '@material-ui/core'
 import { LabeledInputProps } from './types'
 import NumberFormat from 'react-number-format'
-import { InputType } from '../Patterns'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
+import { isNumeric, Patterns } from '../Patterns'
 
 export function LabeledInput (props: LabeledInputProps): ReactElement {
-  const { strongLabel, label, register, error, required = false, patternConfig, name, rules = {}, defaultValue = '' } = props
+  const { strongLabel, label, error, required = false, patternConfig = Patterns.plain, name, rules = {}, defaultValue = '' } = props
+
+  const { control, register } = useFormContext()
 
   const errorMessage: string | undefined = (() => {
     if (error?.message !== undefined && error?.message !== '') {
       return error?.message
     }
-    if (error?.type === 'max' && patternConfig?.inputType === InputType.numeric && patternConfig.max !== undefined) {
-      return `Input must be less than or equal to ${patternConfig.max}`
-    }
-    if (error?.type === 'min' && patternConfig?.inputType === InputType.numeric && patternConfig.min !== undefined) {
-      return `Input must be greater than or equal to ${patternConfig.min}`
+    if (patternConfig !== undefined && isNumeric(patternConfig)) {
+      if (error?.type === 'max' && patternConfig.max !== undefined) {
+        return `Input must be less than or equal to ${patternConfig.max}`
+      }
+      if (error?.type === 'min' && patternConfig.min !== undefined) {
+        return `Input must be greater than or equal to ${patternConfig.min}`
+      }
     }
   })()
 
   const input: ReactElement = (() => {
-    if (patternConfig?.inputType === InputType.numeric) {
+    if (isNumeric(patternConfig)) {
       return (
         <Controller
           render={({ onChange, value }) =>
@@ -41,7 +45,7 @@ export function LabeledInput (props: LabeledInputProps): ReactElement {
             />
           }
           name={name}
-          control={patternConfig.control}
+          control={control}
           required={required}
           defaultValue={defaultValue}
           rules={{

--- a/src/components/input/LabeledRadio.tsx
+++ b/src/components/input/LabeledRadio.tsx
@@ -1,13 +1,14 @@
 import React, { ReactElement } from 'react'
 import { FormControl, FormControlLabel, Radio, RadioGroup } from '@material-ui/core'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { LabeledRadioProps } from './types'
 import useStyles from './styles'
 
 export function LabeledRadio (props: LabeledRadioProps): ReactElement {
-  const { label, name, control, defaultValue, values } = props
+  const { label, name, defaultValue, values } = props
 
   const classes = useStyles()
+  const { control } = useFormContext()
 
   return (
     <Controller

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -1,6 +1,6 @@
 import { BaseFormProps } from '../types'
-import { Control, FieldError, RegisterOptions } from 'react-hook-form'
-import { Pattern } from '../Patterns'
+import { FieldError, RegisterOptions } from 'react-hook-form'
+import { PatternConfig } from '../Patterns'
 export * from '../types'
 
 export interface BaseDropdownProps {
@@ -10,7 +10,6 @@ export interface BaseDropdownProps {
   name: string
   error?: FieldError
   defaultValue?: string
-  control?: Control<any>
 }
 
 export interface CurrencyProps {
@@ -28,7 +27,7 @@ export interface LabeledDropdownProps<A> extends BaseDropdownProps {
 
 export interface LabeledInputProps extends BaseFormProps {
   strongLabel?: string
-  patternConfig?: Pattern
+  patternConfig?: PatternConfig
   label: string
   required?: boolean
   name: string
@@ -38,7 +37,6 @@ export interface LabeledInputProps extends BaseFormProps {
 
 export interface LabeledFormProps<A> {
   name: string
-  control: Control<any>
   label: string
   defaultValue?: A
 }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,10 +1,7 @@
-import { DeepMap, FieldError, RegisterOptions } from 'react-hook-form'
-
-export type Register = (rules?: RegisterOptions) => any
+import { DeepMap, FieldError } from 'react-hook-form'
 
 export type Errors<T> = DeepMap<T, FieldError | undefined>
 
 export interface BaseFormProps {
-  register: Register
   error?: FieldError
 }


### PR DESCRIPTION
`react-hook-form`'s `useFormContext` from react-hook-form allows us to summon register and control at the location where they are actually needed, instead of drilling these properties all the way down our tree.

This context exists in `react-hook-form` v6, and this will greatly help the migration to `react-hook-form` 7, currently at version 7.9.0 (see #212). In react-hook-form 7, control is parameterized by the result type of the form.  Without this context, we would have to deal with that at various levels.

I've also simplified the number-format Pattern definitions so they no longer contain the control object, and simplified some code around pattern definitions.