### PR TITLE
Fill previous values for FICA taxes in W2 edit control

### DIFF
--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -122,6 +122,7 @@ export default function W2JobInfo (): ReactElement {
         name="ssWithholding"
         patternConfig={Patterns.currency(control)}
         error={errors.ssWithholding}
+        defaultValue={defaultValues?.ssWithholding.toString()}
       />
 
       <LabeledInput
@@ -132,6 +133,7 @@ export default function W2JobInfo (): ReactElement {
         name="medicareWithholding"
         patternConfig={Patterns.currency(control)}
         error={errors.medicareWithholding}
+        defaultValue={defaultValues?.medicareWithholding.toString()}
       />
 
       <GenericLabeledDropdown


### PR DESCRIPTION
In the 'Edit' control for an existing W2 entry, the fields for SS and Medicare tax withholding would be blank, even if the existing W2 data did have those fields set. It looks like the `defaultValue` property just wasn't set with the existing W2 data, like it is for the other fields.