### PR TITLE
Add react-if and refactor complicated conditionals in jsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16022,6 +16022,11 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.9.0.tgz",
       "integrity": "sha512-1SazsTvsC5A4jLxc8fIf0bB92kEp4MGjP69k8s+2nI1spHPha5UkLwaebOXhO9vY95aGqcyBU67pRiv+6T5KZQ=="
     },
+    "react-if": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-if/-/react-if-4.0.1.tgz",
+      "integrity": "sha512-TyfDGdBrIAHntLM5YkRbszeqcyzucB3m2ddF46XH10wTZ8SE2ZjNPD8qNphTJ+7j36SZ4qMvqmlMntcsczLAXQ=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.9.0",
+    "react-if": "^4.0.1",
     "react-number-format": "^4.6.4",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",

--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren, ReactElement, useState } from 'react'
 import { IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction, ListItemText, Box, Button, unstable_createMuiStrictModeTheme as createMuiTheme, ThemeProvider } from '@material-ui/core'
 import { red } from '@material-ui/core/colors'
 import { Delete, Edit } from '@material-ui/icons'
+import { Else, If, Then } from 'react-if'
 
 interface FormContainerProps {
   onDone: () => void
@@ -150,24 +151,23 @@ const FormListContainer = <A extends object>(props: PropsWithChildren<FormListCo
   return (
     <div>
       {itemDisplay}
-      {(() => {
-        if (formState !== FormState.Closed) {
-          return (
-            <FormContainer
-              onDone={_onDone}
-              onCancel={_onCancel}
-            >
-              {children}
-            </FormContainer>
-          )
-        } else if (max === undefined || items.length < max) {
-          return (
+      <If condition={formState !== FormState.Closed}>
+        <Then>
+          <FormContainer
+            onDone={_onDone}
+            onCancel={_onCancel}
+          >
+            {children}
+          </FormContainer>
+        </Then>
+        <Else>
+          <If condition={max === undefined || items.length < max}>
             <Button type="button" onClick={() => setFormState(FormState.Adding)} variant="contained" color="secondary">
               Add
             </Button>
-          )
-        }
-      })()}
+          </If>
+        </Else>
+      </If>
     </div>
   )
 }

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -7,6 +7,7 @@ import { answerQuestion } from '../redux/actions'
 import { LabeledCheckbox, LabeledInput } from './input'
 import { FormProvider, useForm } from 'react-hook-form'
 import { PagerContext } from './pager'
+import { Else, If, Then } from 'react-if'
 
 const Questions = (): ReactElement => {
   const information = useSelector((state: TaxesState) => state.information)
@@ -52,26 +53,14 @@ const Questions = (): ReactElement => {
             {
               questions.map((q, i) =>
                 <ListItem key={i}>
-                  {(() => {
-                    switch (q.valueTag) {
-                      case 'boolean': {
-                        return (
-                          <LabeledCheckbox
-                            name={q.tag}
-                            label={q.text}
-                          />
-                        )
-                      }
-                      default: {
-                        return (
-                          <LabeledInput
-                            name={q.tag}
-                            label={q.text}
-                          />
-                        )
-                      }
-                    }
-                  })()}
+                  <If condition={q.valueTag === 'boolean'}>
+                    <Then>
+                      <LabeledCheckbox name={q.tag} label={q.text} />
+                    </Then>
+                    <Else>
+                      <LabeledInput name={q.tag} label={q.text} />
+                    </Else>
+                  </If>
                 </ListItem>
               )
             }

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, ReactElement } from 'react'
+import { If } from 'react-if'
 import { Address } from '../../redux/data'
 import { LabeledCheckbox, LabeledInput, USStateDropDown } from '../input'
 import { Patterns } from '../Patterns'
@@ -84,16 +85,9 @@ export default function AddressFields (props: AddressProps): ReactElement {
         required={true}
         error={errors?.city}
       />
-      {(() => {
-        if (allowForeignCountry) {
-          return (
-            <LabeledCheckbox
-              label={checkboxText}
-              name="isForeignCountry"
-            />
-          )
-        }
-      })()}
+      <If condition={allowForeignCountry}>
+        <LabeledCheckbox label={checkboxText} name="isForeignCountry" />
+      </If>
       {csz}
     </Fragment>
   )

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -11,6 +11,7 @@ import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
 import { DeepMap, FieldError } from 'react-hook-form'
+import { If } from 'react-if'
 
 interface PersonFieldsProps extends BaseFormProps {
   children?: ReactNode
@@ -60,17 +61,13 @@ export const PersonListItem = ({ person, remove, onEdit, editing = false }: Pers
       primary={`${person.firstName} ${person.lastName}`}
       secondary={formatSSID(person.ssid)}
     />
-    {(() => {
-      if (editing !== undefined) {
-        return (
-          <ListItemIcon>
-            <IconButton onClick={onEdit} edge="end" aria-label="edit">
-              <EditIcon />
-            </IconButton>
-          </ListItemIcon>
-        )
-      }
-    })()}
+    <If condition={editing !== undefined}>
+      <ListItemIcon>
+        <IconButton onClick={onEdit} edge="end" aria-label="edit">
+          <EditIcon />
+        </IconButton>
+      </ListItemIcon>
+    </If>
     <ListItemSecondaryAction>
       <IconButton onClick={remove} edge="end" aria-label="delete">
         <DeleteIcon />

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -12,6 +12,7 @@ import { HouseOutlined } from '@material-ui/icons'
 import { FormListContainer } from '../FormContainer'
 import { Grid } from '@material-ui/core'
 import { CURRENT_YEAR } from '../../data/federal'
+import { If } from 'react-if'
 
 interface PropertyAddForm {
   address?: Address
@@ -227,18 +228,14 @@ export default function RealEstate (): ReactElement {
         name="propertyType"
         valueMapping={(n) => n}
       />
-      {(() => {
-        if ([propertyType, defaultValues?.propertyType].includes('other')) {
-          return (
-            <LabeledInput
-              name="otherPropertyType"
-              label="Short property type description"
-              error={errors.otherPropertyType}
-              required={true}
-            />
-          )
-        }
-      })()}
+      <If condition={[propertyType, defaultValues?.propertyType].includes('other')}>
+        <LabeledInput
+          name="otherPropertyType"
+          label="Short property type description"
+          error={errors.otherPropertyType}
+          required={true}
+        />
+      </If>
       <h4>Use</h4>
       <LabeledInput
         name="rentalDays"
@@ -269,23 +266,21 @@ export default function RealEstate (): ReactElement {
       />
       <h5>Expenses</h5>
       <Grid container spacing={3} direction="row" justify="flex-start">
-        {(() => {
+        {
           // Layout expense fields in two columns
-          return (
-            segments(2, [...expenseFields, otherExpenseDescription])
-              .map((segment, i) =>
-                <Grid item key={i} lg={6}>
-                  {
-                    segment.map((item, k) =>
-                      <Fragment key={`${i}-${k}`}>
-                        {item}
-                      </Fragment>
-                    )
-                  }
-                </Grid>
-              )
-          )
-        })()}
+          segments(2, [...expenseFields, otherExpenseDescription])
+            .map((segment, i) =>
+              <Grid item key={i} lg={6}>
+                {
+                  segment.map((item, k) =>
+                    <Fragment key={`${i}-${k}`}>
+                      {item}
+                    </Fragment>
+                  )
+                }
+              </Grid>
+            )
+        }
       </Grid>
     </FormListContainer>
   )


### PR DESCRIPTION
This adds react-if and refactors a few confusing conditional places where the `<If>` component feels a little more natural. Also refactors the `<Summary>` component where it was not natural to use `If` but the render block was just too complex.

Because jsx `{ }`s can only contain expressions and not statements, to convert an if statement into an expression we had to use anonymous functions:

```tsx
<div>
  {(() => {
    if (condition) { return "info" }
    // no return === undefined, which is a valid ReactNode
  })()}
</div>
```

But instead of doing the above, we can just use `<If>`:

```tsx
<div>
  <If condition={condition}>
    info
  </If>
</div>
```

There are a couple downsides to this: 

* the block inside `<If></If>` will be evaluated regardless of the condition
* Union types are not resolved at compile time:

```tsx
type Result = undefined | string
const result: Result

if (result !== undefined) {
   result.length // ok
}

<If condition={result !== undefined}>
  {result.length} // compile time error
</If>
```