### PR TITLE
Remove need to pass error to every field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2743,6 +2743,21 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.171",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "@types/lodash.get": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
+      "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
@@ -12586,6 +12601,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@tauri-apps/api": "^1.0.0-beta.4",
     "@tauri-apps/cli": "^1.0.0-beta.5",
     "ajv": "^8.6.1",
+    "lodash.get": "^4.4.2",
     "loglevel": "^1.7.1",
     "node-fetch": "^2.6.1",
     "pdf-lib": "^1.16.0",
@@ -57,6 +58,7 @@
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.1.9",
     "@types/jest": "^26.0.23",
+    "@types/lodash.get": "^4.4.6",
     "@types/node": "^16.0.0",
     "@types/node-fetch": "^2.5.10",
     "@types/react": "^17.0.13",
@@ -73,8 +75,8 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-standard": "^5.0.0",
-    "husky": "^7.0.0",
     "fast-check": "^2.17.0",
+    "husky": "^7.0.0",
     "typescript-eslint": "0.0.1-alpha.0"
   },
   "husky": {

--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -22,7 +22,7 @@ export default function RefundBankAccount (): ReactElement {
   })
 
   const methods = useForm<UserRefundForm>({ defaultValues })
-  const { handleSubmit, formState: { errors } } = methods
+  const { handleSubmit } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -44,7 +44,6 @@ export default function RefundBankAccount (): ReactElement {
               required={true}
               patternConfig={Patterns.bankRouting}
               name="routingNumber"
-              error={errors.routingNumber}
             />
 
             <LabeledInput
@@ -52,7 +51,6 @@ export default function RefundBankAccount (): ReactElement {
               required={true}
               patternConfig={Patterns.bankAccount}
               name="accountNumber"
-              error={errors.accountNumber}
             />
             <LabeledRadio
               label="Account Type"

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, ReactElement } from 'react'
 import { If } from 'react-if'
-import { Address } from '../../redux/data'
 import { LabeledCheckbox, LabeledInput, USStateDropDown } from '../input'
 import { Patterns } from '../Patterns'
 

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,12 +1,9 @@
 import React, { Fragment, ReactElement } from 'react'
-import { Address } from '../../redux/data'
 import { LabeledCheckbox, LabeledInput, USStateDropDown } from '../input'
 import { Patterns } from '../Patterns'
-import { Errors } from '../types'
 
 interface AddressProps {
   checkboxText: string
-  errors?: Errors<Address>
   isForeignCountry?: boolean
   allowForeignCountry?: boolean
 }
@@ -14,7 +11,6 @@ interface AddressProps {
 export default function AddressFields (props: AddressProps): ReactElement {
   const {
     isForeignCountry = false,
-    errors,
     checkboxText = 'Check if you have a foreign address',
     allowForeignCountry = true
   } = props
@@ -26,12 +22,10 @@ export default function AddressFields (props: AddressProps): ReactElement {
           <USStateDropDown
             label="State"
             name="address.state"
-            error={errors?.state}
             required={!isForeignCountry}
           />
           <LabeledInput
             label="Zip"
-            error={errors?.zip}
             name="address.zip"
             patternConfig={Patterns.zip}
             required={!isForeignCountry}
@@ -44,19 +38,16 @@ export default function AddressFields (props: AddressProps): ReactElement {
         <LabeledInput
           label="Province"
           name="address.province"
-          error={errors?.province}
           required={isForeignCountry}
         />
         <LabeledInput
           name="address.postalCode"
           label="Postal Code"
-          error={errors?.postalCode}
           required={isForeignCountry}
         />
         <LabeledInput
           name="address.foreignCountry"
           label="Country"
-          error={errors?.foreignCountry}
           required={isForeignCountry}
         />
       </div>
@@ -69,20 +60,17 @@ export default function AddressFields (props: AddressProps): ReactElement {
         label="Address"
         name="address.address"
         required={true}
-        error={errors?.address}
       />
       <LabeledInput
         label="Unit No"
         name="address.aptNo"
         required={false}
-        error={errors?.aptNo}
       />
       <LabeledInput
         label="City"
         name="address.city"
         patternConfig={Patterns.name}
         required={true}
-        error={errors?.city}
       />
       {(() => {
         if (allowForeignCountry) {

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -16,7 +16,7 @@ export default function ContactInfo (): ReactElement {
   })
 
   const methods = useForm<Contact>({ defaultValues })
-  const { handleSubmit, formState: { errors } } = methods
+  const { handleSubmit } = methods
 
   const onSubmit = (onAdvance: () => void) => (formData: Contact): void => {
     dispatch(saveContactInfo(formData))
@@ -33,13 +33,11 @@ export default function ContactInfo (): ReactElement {
             required={true}
             patternConfig={Patterns.usPhoneNumber}
             name="contactPhoneNumber"
-            error={errors.contactPhoneNumber}
           />
           <LabeledInput
             label="Contact email address"
             required={true}
             name="contactEmail"
-            error={errors.contactEmail}
           />
           {navButtons}
         </form>

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -1,47 +1,37 @@
-import React, { ReactElement, ReactNode } from 'react'
+import React, { Fragment, PropsWithChildren, ReactElement } from 'react'
 import { IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import { formatSSID, LabeledInput } from '../input'
 import { Patterns } from '../Patterns'
 import { Actions, removeDependent } from '../../redux/actions'
 import { TaxesState, Person } from '../../redux/data'
-import { BaseFormProps } from '../types'
 import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
-import { DeepMap, FieldError } from 'react-hook-form'
 
-interface PersonFieldsProps extends BaseFormProps {
-  children?: ReactNode
-  errors: DeepMap<Partial<Person>, FieldError>
-}
-
-export const PersonFields = ({ errors, children }: PersonFieldsProps): ReactElement => (
-  <div>
+export const PersonFields = ({ children }: PropsWithChildren<{}>): ReactElement => (
+  <Fragment>
     <LabeledInput
       label="First Name and Initial"
       name="firstName"
       patternConfig={Patterns.name}
       required={true}
-      error={errors.firstName}
     />
     <LabeledInput
       label="Last Name"
       name="lastName"
       patternConfig={Patterns.name}
       required={true}
-      error={errors.lastName}
     />
     <LabeledInput
       label="SSN / TIN"
       name="ssid"
       patternConfig={Patterns.ssn}
       required={true}
-      error={errors.ssid}
     />
     {children}
-  </div>
+  </Fragment>
 )
 
 interface PersonListItemProps {

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -9,7 +9,6 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
-import { DeepMap, FieldError } from 'react-hook-form'
 import { If } from 'react-if'
 
 export const PersonFields = ({ children }: PropsWithChildren<{}>): ReactElement => (

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -71,7 +71,7 @@ export const AddDependentForm = (): ReactElement => {
   const dispatch = useDispatch()
 
   const methods = useForm<UserDependentForm>()
-  const { formState: { errors }, handleSubmit, reset } = methods
+  const { handleSubmit, reset } = methods
 
   const setEditing = (idx: number): void => {
     reset(toDependentForm(dependents[idx]))
@@ -105,27 +105,24 @@ export const AddDependentForm = (): ReactElement => {
       icon={() => <Person />}
       removeItem={(i) => dispatch(removeDependent(i))}
     >
-      <PersonFields errors={errors} />
+      <PersonFields />
       <LabeledInput
         label="Relationship to Taxpayer"
         name="relationship"
         required={true}
         patternConfig={Patterns.name}
-        error={errors.relationship}
       />
       <LabeledInput
         label="Birth Year"
         patternConfig={Patterns.year}
         name="birthYear"
         required={true}
-        error={errors.birthYear}
       />
       <LabeledInput
         label="How many months did you live together this year?"
         patternConfig={Patterns.numMonths}
         name="numberOfMonths"
         required={true}
-        error={errors.numberOfMonths}
       />
       <LabeledCheckbox
         label="Is this person a full-time student?"
@@ -139,7 +136,7 @@ export const AddDependentForm = (): ReactElement => {
 
 export const SpouseInfo = (): ReactElement => {
   const methods = useForm<UserSpouseForm>()
-  const { formState: { errors }, handleSubmit, getValues, reset } = methods
+  const { handleSubmit, getValues, reset } = methods
   const [editing, doSetEditing] = useState<boolean>(false)
   const dispatch = useDispatch()
 
@@ -178,7 +175,7 @@ export const SpouseInfo = (): ReactElement => {
       editing={editing ? 0 : undefined}
       removeItem={() => dispatch(removeSpouse)}
     >
-      <PersonFields errors={errors}>
+      <PersonFields>
         <LabeledCheckbox
           label="Check if your spouse is a dependent"
           name="isTaxpayerDependent"
@@ -196,7 +193,7 @@ const SpouseAndDependent = (): ReactElement => {
   })
 
   const methods = useForm<{ filingStatus: FilingStatus }>({ defaultValues: { filingStatus: taxPayer.filingStatus } })
-  const { handleSubmit, formState: { errors } } = methods
+  const { handleSubmit } = methods
   // const variable dispatch to allow use inside function
   const dispatch = useDispatch()
 
@@ -223,7 +220,6 @@ const SpouseAndDependent = (): ReactElement => {
             dropDownData={filingStatuses(taxPayer)}
             valueMapping={(x, i) => x}
             keyMapping={(x, i) => i}
-            error={errors.filingStatus}
             textMapping={status => FilingStatusTexts[status]}
             required={true}
             name="filingStatus"

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -35,7 +35,7 @@ export default function PrimaryTaxpayer (): ReactElement {
   })
 
   const methods = useForm<PrimaryPerson>({ defaultValues: taxPayer.primaryPerson })
-  const { handleSubmit, control, formState: { errors } } = methods
+  const { handleSubmit, control } = methods
 
   const isForeignCountry: boolean = useWatch({
     control,
@@ -53,15 +53,12 @@ export default function PrimaryTaxpayer (): ReactElement {
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
           <h2>Primary Taxpayer Information</h2>
-          <PersonFields
-            errors={errors}
-          />
+          <PersonFields />
           <LabeledCheckbox
             label="Check if you are a dependent"
             name="isTaxpayerDependent"
           />
           <AddressFields
-            errors={errors.address}
             checkboxText="Do you have a foreign address?"
             isForeignCountry={isForeignCountry}
           />

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -50,7 +50,7 @@ export default function F1098eInfo (): ReactElement {
   })()
 
   const methods = useForm<F1098EUserInput>({ defaultValues })
-  const { formState: { errors }, handleSubmit, reset } = methods
+  const { handleSubmit, reset } = methods
 
   const dispatch = useDispatch()
 
@@ -93,16 +93,14 @@ export default function F1098eInfo (): ReactElement {
       required={true}
       patternConfig={Patterns.name}
       name="lender"
-      error={errors.lender}
     />
 
     <LabeledInput
-        label="Student Interest Paid"
-        required={true}
-        patternConfig={Patterns.currency}
-        name="interest"
-        error={errors.interest}
-      />
+      label="Student Interest Paid"
+      required={true}
+      patternConfig={Patterns.currency}
+      name="interest"
+    />
 
     </FormListContainer>
   )

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -253,7 +253,6 @@ export default function F1099Info (): ReactElement {
 
       <GenericLabeledDropdown
         dropDownData={Object.values(Income1099Type)}
-
         label="Form Type"
         required={true}
         valueMapping={(v: Income1099Type) => v}
@@ -267,14 +266,12 @@ export default function F1099Info (): ReactElement {
         required={true}
         patternConfig={Patterns.name}
         name="payer"
-
       />
 
       {selectedType !== undefined ? specificFields[selectedType] : undefined }
 
       <GenericLabeledDropdown
         dropDownData={people}
-
         label="Recipient"
         required={true}
         valueMapping={(p: Person, i: number) => [PersonRole.PRIMARY, PersonRole.SPOUSE][i]}

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -130,7 +130,7 @@ export default function F1099Info (): ReactElement {
   const [editing, doSetEditing] = useState<number | undefined>(undefined)
 
   const methods = useForm<F1099UserInput>()
-  const { formState: { errors }, handleSubmit, reset, watch, setValue } = methods
+  const { handleSubmit, reset, watch, setValue } = methods
   const selectedType: Income1099Type | undefined = watch('formType')
 
   const dispatch = useDispatch()
@@ -174,7 +174,6 @@ export default function F1099Info (): ReactElement {
       required={true}
       patternConfig={Patterns.currency}
       name="interest"
-      error={errors.interest}
     />
   )
 
@@ -186,14 +185,12 @@ export default function F1099Info (): ReactElement {
         required={true}
         patternConfig={Patterns.currency}
         name="longTermProceeds"
-        error={errors.longTermProceeds}
       />
       <LabeledInput
         label="Cost basis"
         required={true}
         patternConfig={Patterns.currency}
         name="longTermCostBasis"
-        error={errors.longTermCostBasis}
       />
       <h4>Short Term Covered Transactions</h4>
       <LabeledInput
@@ -201,14 +198,12 @@ export default function F1099Info (): ReactElement {
         required={true}
         patternConfig={Patterns.currency}
         name="shortTermProceeds"
-        error={errors.shortTermProceeds}
       />
       <LabeledInput
         label="Cost basis"
         required={true}
         patternConfig={Patterns.currency}
         name="shortTermCostBasis"
-        error={errors.shortTermCostBasis}
       />
     </div>
   )
@@ -220,14 +215,12 @@ export default function F1099Info (): ReactElement {
         required={true}
         patternConfig={Patterns.currency}
         name="dividends"
-        error={errors.dividends}
       />
       <LabeledInput
         label="Qualified Dividends"
         required={true}
         patternConfig={Patterns.currency}
         name="qualifiedDividends"
-        error={errors.qualifiedDividends}
       />
     </div>
   )
@@ -260,7 +253,7 @@ export default function F1099Info (): ReactElement {
 
       <GenericLabeledDropdown
         dropDownData={Object.values(Income1099Type)}
-        error={errors.formType}
+
         label="Form Type"
         required={true}
         valueMapping={(v: Income1099Type) => v}
@@ -274,14 +267,14 @@ export default function F1099Info (): ReactElement {
         required={true}
         patternConfig={Patterns.name}
         name="payer"
-        error={errors.payer}
+
       />
 
       {selectedType !== undefined ? specificFields[selectedType] : undefined }
 
       <GenericLabeledDropdown
         dropDownData={people}
-        error={errors.personRole}
+
         label="Recipient"
         required={true}
         valueMapping={(p: Person, i: number) => [PersonRole.PRIMARY, PersonRole.SPOUSE][i]}

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -119,7 +119,7 @@ const toUserInput = (property: Property): PropertyAddForm => {
 
 export default function RealEstate (): ReactElement {
   const methods = useForm<PropertyAddForm>()
-  const { control, formState: { errors }, getValues, handleSubmit, reset } = methods
+  const { control, getValues, handleSubmit, reset } = methods
   const dispatch = useDispatch()
 
   const properties: Property[] = useSelector((state: TaxesState) => state.information.realEstate)
@@ -213,14 +213,12 @@ export default function RealEstate (): ReactElement {
     >
       <h4>Property location</h4>
       <AddressFields
-        errors={errors.address}
         checkboxText="Does the property have a foreign address"
         allowForeignCountry={false}
       />
       <GenericLabeledDropdown
         dropDownData={enumKeys(PropertyType)}
         label="Property type"
-        error={errors.propertyType}
         required={true}
         textMapping={(t) => displayPropertyType(PropertyType[t])}
         keyMapping={(_, n) => n}
@@ -233,7 +231,6 @@ export default function RealEstate (): ReactElement {
             <LabeledInput
               name="otherPropertyType"
               label="Short property type description"
-              error={errors.otherPropertyType}
               required={true}
             />
           )
@@ -246,14 +243,12 @@ export default function RealEstate (): ReactElement {
         rules={{ validate: (n: String) => validateRental(Number(n)) }}
         label="Number of days in the year used for rental"
         patternConfig={Patterns.numDays}
-        error={errors.rentalDays}
       />
       <LabeledInput
         name="personalUseDays"
         rules={{ validate: (n: String) => validatePersonal(Number(n)) }}
         label="Number of days in the year for personal use"
         patternConfig={Patterns.numDays}
-        error={errors.personalUseDays}
       />
       <LabeledCheckbox
         name="qualifiedJointVenture"
@@ -265,7 +260,6 @@ export default function RealEstate (): ReactElement {
         name="rentReceived"
         label="Rent received"
         patternConfig={Patterns.currency}
-        error={errors.rentReceived}
       />
       <h5>Expenses</h5>
       <Grid container spacing={3} direction="row" justify="flex-start">

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -42,7 +42,7 @@ export default function W2JobInfo (): ReactElement {
   const [editing, doSetEditing] = useState<number | undefined>(undefined)
 
   const methods = useForm<IncomeW2UserInput>()
-  const { formState: { errors }, handleSubmit, reset } = methods
+  const { handleSubmit, reset } = methods
 
   const people: Person[] = (
     useSelector((state: TaxesState) => ([
@@ -95,7 +95,6 @@ export default function W2JobInfo (): ReactElement {
         label="Occupation"
         required={true}
         name="occupation"
-        error={errors.occupation}
       />
 
       <LabeledInput
@@ -104,7 +103,6 @@ export default function W2JobInfo (): ReactElement {
         required={true}
         patternConfig={Patterns.currency}
         name="income"
-        error={errors.income}
       />
 
       <LabeledInput
@@ -113,7 +111,6 @@ export default function W2JobInfo (): ReactElement {
         required={true}
         name="fedWithholding"
         patternConfig={Patterns.currency}
-        error={errors.fedWithholding}
       />
 
       <LabeledInput
@@ -122,7 +119,6 @@ export default function W2JobInfo (): ReactElement {
         required={true}
         name="ssWithholding"
         patternConfig={Patterns.currency}
-        error={errors.ssWithholding}
       />
 
       <LabeledInput
@@ -131,12 +127,10 @@ export default function W2JobInfo (): ReactElement {
         required={true}
         name="medicareWithholding"
         patternConfig={Patterns.currency}
-        error={errors.medicareWithholding}
       />
 
       <GenericLabeledDropdown
         dropDownData={people}
-        error={errors.personRole}
         label="Employee"
         required={true}
         valueMapping={(p: Person, i: number) => [PersonRole.PRIMARY, PersonRole.SPOUSE][i]}

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -3,10 +3,12 @@ import { Box, TextField } from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import locationPostalCodes from '../../data/locationPostalCodes'
 import { BaseDropdownProps, LabeledDropdownProps } from './types'
+import _ from 'lodash'
 
 export function GenericLabeledDropdown<A> (props: LabeledDropdownProps<A>): ReactElement {
-  const { control } = useFormContext()
-  const { strongLabel, label, dropDownData, valueMapping, error, keyMapping, textMapping, required = false, name } = props
+  const { control, formState: { errors } } = useFormContext()
+  const { strongLabel, label, dropDownData, valueMapping, keyMapping, textMapping, required = false, name } = props
+  const error = _.get(errors, name)
 
   return (
     <div>

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -6,9 +6,10 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { isNumeric, Patterns } from '../Patterns'
 
 export function LabeledInput (props: LabeledInputProps): ReactElement {
-  const { strongLabel, label, error, required = false, patternConfig = Patterns.plain, name, rules = {} } = props
+  const { strongLabel, label, required = false, patternConfig = Patterns.plain, name, rules = {} } = props
 
-  const { control, register } = useFormContext()
+  const { control, register, formState: { errors } } = useFormContext()
+  const error = errors[name]
 
   const errorMessage: string | undefined = (() => {
     if (error?.message !== undefined && error?.message !== '') {

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -4,12 +4,13 @@ import { LabeledInputProps } from './types'
 import NumberFormat from 'react-number-format'
 import { Controller, useFormContext } from 'react-hook-form'
 import { isNumeric, Patterns } from '../Patterns'
+import _ from 'lodash'
 
 export function LabeledInput (props: LabeledInputProps): ReactElement {
   const { strongLabel, label, required = false, patternConfig = Patterns.plain, name, rules = {} } = props
 
   const { control, register, formState: { errors } } = useFormContext()
-  const error = errors[name]
+  const error = _.get(errors, name)
 
   const errorMessage: string | undefined = (() => {
     if (error?.message !== undefined && error?.message !== '') {

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -1,14 +1,11 @@
-import { BaseFormProps } from '../types'
-import { FieldError, RegisterOptions } from 'react-hook-form'
+import { RegisterOptions } from 'react-hook-form'
 import { PatternConfig } from '../Patterns'
-export * from '../types'
 
 export interface BaseDropdownProps {
   label: string
   strongLabel?: string
   required?: boolean
   name: string
-  error?: FieldError
 }
 
 export interface CurrencyProps {
@@ -24,7 +21,7 @@ export interface LabeledDropdownProps<A> extends BaseDropdownProps {
   textMapping: (a: A, n: number) => string
 }
 
-export interface LabeledInputProps extends BaseFormProps {
+export interface LabeledInputProps {
   strongLabel?: string
   patternConfig?: PatternConfig
   label: string

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,7 +1,0 @@
-import { DeepMap, FieldError } from 'react-hook-form'
-
-export type Errors<T> = DeepMap<T, FieldError | undefined>
-
-export interface BaseFormProps {
-  error?: FieldError
-}


### PR DESCRIPTION
The error value is already available from the form's context, and looking up the error only requires the name property, so we're able to remove a lot of duplicated work by just looking up the error where it is actually needed.

This PR should introduce no visible behavior changes. Adds `_.get` from `lodash` to get nested properties from `DeepMap`, for example if errors is `{'address': {'state': error_obj}}`, then `error_obj` can be accessed by `address.state`.