### PR TITLE
Remove required=true on almost all form fields

### DIFF
--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -41,7 +41,6 @@ export default function RefundBankAccount (): ReactElement {
 
             <LabeledInput
               label="Bank Routing number"
-              required={true}
               patternConfig={Patterns.bankRouting}
               name="routingNumber"
               error={errors.routingNumber}
@@ -49,7 +48,6 @@ export default function RefundBankAccount (): ReactElement {
 
             <LabeledInput
               label="Bank Account number"
-              required={true}
               patternConfig={Patterns.bankAccount}
               name="accountNumber"
               error={errors.accountNumber}

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -81,7 +81,6 @@ export default function AddressFields (props: AddressProps): ReactElement {
         label="City"
         name="address.city"
         patternConfig={Patterns.name}
-        required={true}
         error={errors?.city}
       />
       {(() => {

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -30,7 +30,6 @@ export default function ContactInfo (): ReactElement {
           <h2>Family Contact Information</h2>
           <LabeledInput
             label="Contact phone number"
-            required={true}
             patternConfig={Patterns.usPhoneNumber}
             name="contactPhoneNumber"
             error={errors.contactPhoneNumber}

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -23,21 +23,18 @@ export const PersonFields = ({ errors, children }: PersonFieldsProps): ReactElem
       label="First Name and Initial"
       name="firstName"
       patternConfig={Patterns.name}
-      required={true}
       error={errors.firstName}
     />
     <LabeledInput
       label="Last Name"
       name="lastName"
       patternConfig={Patterns.name}
-      required={true}
       error={errors.lastName}
     />
     <LabeledInput
       label="SSN / TIN"
       name="ssid"
       patternConfig={Patterns.ssn}
-      required={true}
       error={errors.ssid}
     />
     {children}

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -109,7 +109,6 @@ export const AddDependentForm = (): ReactElement => {
       <LabeledInput
         label="Relationship to Taxpayer"
         name="relationship"
-        required={true}
         patternConfig={Patterns.name}
         error={errors.relationship}
       />
@@ -117,14 +116,12 @@ export const AddDependentForm = (): ReactElement => {
         label="Birth Year"
         patternConfig={Patterns.year}
         name="birthYear"
-        required={true}
         error={errors.birthYear}
       />
       <LabeledInput
         label="How many months did you live together this year?"
         patternConfig={Patterns.numMonths}
         name="numberOfMonths"
-        required={true}
         error={errors.numberOfMonths}
       />
       <LabeledCheckbox
@@ -225,7 +222,6 @@ const SpouseAndDependent = (): ReactElement => {
             keyMapping={(x, i) => i}
             error={errors.filingStatus}
             textMapping={status => FilingStatusTexts[status]}
-            required={true}
             name="filingStatus"
           />
           {navButtons}

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -90,7 +90,6 @@ export default function F1098eInfo (): ReactElement {
 
     <LabeledInput
       label="Enter name of Lender"
-      required={true}
       patternConfig={Patterns.name}
       name="lender"
       error={errors.lender}
@@ -98,7 +97,6 @@ export default function F1098eInfo (): ReactElement {
 
     <LabeledInput
         label="Student Interest Paid"
-        required={true}
         patternConfig={Patterns.currency}
         name="interest"
         error={errors.interest}

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -170,7 +170,8 @@ export default function F1099Info (): ReactElement {
 
   const intFields = (
     <LabeledInput
-      label="Box 1 - Interest Income" patternConfig={Patterns.currency}
+      label="Box 1 - Interest Income"
+      patternConfig={Patterns.currency}
       name="interest"
       error={errors.interest}
     />

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -170,9 +170,7 @@ export default function F1099Info (): ReactElement {
 
   const intFields = (
     <LabeledInput
-      label="Box 1 - Interest Income"
-      required={true}
-      patternConfig={Patterns.currency}
+      label="Box 1 - Interest Income" patternConfig={Patterns.currency}
       name="interest"
       error={errors.interest}
     />
@@ -183,14 +181,12 @@ export default function F1099Info (): ReactElement {
       <h4>Long Term Covered Transactions</h4>
       <LabeledInput
         label="Proceeds"
-        required={true}
         patternConfig={Patterns.currency}
         name="longTermProceeds"
         error={errors.longTermProceeds}
       />
       <LabeledInput
         label="Cost basis"
-        required={true}
         patternConfig={Patterns.currency}
         name="longTermCostBasis"
         error={errors.longTermCostBasis}
@@ -198,14 +194,12 @@ export default function F1099Info (): ReactElement {
       <h4>Short Term Covered Transactions</h4>
       <LabeledInput
         label="Proceeds"
-        required={true}
         patternConfig={Patterns.currency}
         name="shortTermProceeds"
         error={errors.shortTermProceeds}
       />
       <LabeledInput
         label="Cost basis"
-        required={true}
         patternConfig={Patterns.currency}
         name="shortTermCostBasis"
         error={errors.shortTermCostBasis}
@@ -217,14 +211,12 @@ export default function F1099Info (): ReactElement {
     <div>
       <LabeledInput
         label="Total Dividends"
-        required={true}
         patternConfig={Patterns.currency}
         name="dividends"
         error={errors.dividends}
       />
       <LabeledInput
         label="Qualified Dividends"
-        required={true}
         patternConfig={Patterns.currency}
         name="qualifiedDividends"
         error={errors.qualifiedDividends}
@@ -262,7 +254,6 @@ export default function F1099Info (): ReactElement {
         dropDownData={Object.values(Income1099Type)}
         error={errors.formType}
         label="Form Type"
-        required={true}
         valueMapping={(v: Income1099Type) => v}
         name="formType"
         keyMapping={(_, i: number) => i}
@@ -271,7 +262,6 @@ export default function F1099Info (): ReactElement {
 
       <LabeledInput
         label="Enter name of bank, broker firm, or other payer"
-        required={true}
         patternConfig={Patterns.name}
         name="payer"
         error={errors.payer}
@@ -283,7 +273,6 @@ export default function F1099Info (): ReactElement {
         dropDownData={people}
         error={errors.personRole}
         label="Recipient"
-        required={true}
         valueMapping={(p: Person, i: number) => [PersonRole.PRIMARY, PersonRole.SPOUSE][i]}
         name="personRole"
         keyMapping={(p: Person, i: number) => i}

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -221,7 +221,6 @@ export default function RealEstate (): ReactElement {
         dropDownData={enumKeys(PropertyType)}
         label="Property type"
         error={errors.propertyType}
-        required={true}
         textMapping={(t) => displayPropertyType(PropertyType[t])}
         keyMapping={(_, n) => n}
         name="propertyType"
@@ -242,7 +241,6 @@ export default function RealEstate (): ReactElement {
       <h4>Use</h4>
       <LabeledInput
         name="rentalDays"
-        required={true}
         rules={{ validate: (n: String) => validateRental(Number(n)) }}
         label="Number of days in the year used for rental"
         patternConfig={Patterns.numDays}

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -93,7 +93,7 @@ export default function W2JobInfo (): ReactElement {
       <strong>Input data from W-2</strong>
       <LabeledInput
         label="Occupation"
-        required={true}
+        patternConfig={Patterns.name}
         name="occupation"
         error={errors.occupation}
       />
@@ -101,7 +101,6 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 1 - "
         label="Wages, tips, other compensation"
-        required={true}
         patternConfig={Patterns.currency}
         name="income"
         error={errors.income}
@@ -110,7 +109,6 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 2 - "
         label="Federal income tax withheld"
-        required={true}
         name="fedWithholding"
         patternConfig={Patterns.currency}
         error={errors.fedWithholding}
@@ -119,7 +117,6 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 4 - "
         label="Social security tax withheld"
-        required={true}
         name="ssWithholding"
         patternConfig={Patterns.currency}
         error={errors.ssWithholding}
@@ -128,7 +125,6 @@ export default function W2JobInfo (): ReactElement {
       <LabeledInput
         strongLabel="Box 6 - "
         label="Medicare tax withheld"
-        required={true}
         name="medicareWithholding"
         patternConfig={Patterns.currency}
         error={errors.medicareWithholding}

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -6,7 +6,7 @@ import { BaseDropdownProps, LabeledDropdownProps } from './types'
 
 export function GenericLabeledDropdown<A> (props: LabeledDropdownProps<A>): ReactElement {
   const { control } = useFormContext()
-  const { strongLabel, label, dropDownData, valueMapping, error, keyMapping, textMapping, required = false, name } = props
+  const { strongLabel, label, dropDownData, valueMapping, error, keyMapping, textMapping, required = true, name } = props
 
   return (
     <div>

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -6,7 +6,9 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { isNumeric, Patterns } from '../Patterns'
 
 export function LabeledInput (props: LabeledInputProps): ReactElement {
-  const { strongLabel, label, error, required = false, patternConfig = Patterns.plain, name, rules = {} } = props
+  const { strongLabel, label, error, patternConfig: patternConfigDefined, name, rules = {} } = props
+  const { required = patternConfigDefined !== undefined } = props
+  const { patternConfig = Patterns.plain } = props
 
   const { control, register } = useFormContext()
 


### PR DESCRIPTION
A pattern object is passed which specifies the format the input can have. Passing this pattern object implies that the field is required, so specifying required=true on such fields is redundant.

On text inputs it makes required default true if `patternConfig` is defined.

Dropdowns are required default true.