### PR TITLE
Add fields component to reduce repetition

### DIFF
--- a/src/components/Fields.tsx
+++ b/src/components/Fields.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement, Fragment, PropsWithChildren } from 'react'
+import { RegisterOptions } from 'react-hook-form'
+import { LabeledCheckbox, LabeledInput, USStateDropDown } from './input'
+import { CountryDropDown } from './input/LabeledDropdown'
+import { PatternConfig } from './Patterns'
+
+type FieldType = 'text' | 'country' | 'state' | 'checkbox'
+type Rules = Exclude<RegisterOptions, 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>
+
+export interface FieldDef {
+  label: string
+  name: string
+  patternConfig?: PatternConfig
+  required?: boolean
+  fieldType?: FieldType
+  strongLabel?: string
+  rules?: Rules
+}
+
+interface FieldsProps {
+  fields: FieldDef[]
+}
+
+interface FieldProps {
+  field: FieldDef
+}
+
+export const field = (
+  label: string,
+  name: string,
+  patternConfig?: PatternConfig,
+  fieldType?: FieldType,
+  required?: boolean,
+  strongLabel?: string,
+  rules?: Rules
+): FieldDef => (
+  { label, name, patternConfig, required, fieldType, strongLabel, rules }
+)
+
+export const Field = ({ field: { fieldType, ...field }, children }: PropsWithChildren<FieldProps>): ReactElement => {
+  switch (fieldType) {
+    case 'checkbox': {
+      return <LabeledCheckbox {...field} />
+    }
+    case 'state': {
+      return <USStateDropDown {...field} />
+    }
+    case 'country': {
+      return <CountryDropDown {...field} />
+    }
+    default: {
+      return <LabeledInput {...field} />
+    }
+  }
+}
+
+export const Fields = ({ fields, children }: PropsWithChildren<FieldsProps>): ReactElement => (
+  <Fragment>
+    {fields.map((field, key) => <Field key={key} field={field} />)}
+    {children}
+  </Fragment>
+)

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -4,10 +4,9 @@ import { useDispatch, useSelector } from 'react-redux'
 import { getRequiredQuestions, QuestionTagName, Responses } from '../data/questions'
 import { TaxesState } from '../redux/data'
 import { answerQuestion } from '../redux/actions'
-import { LabeledCheckbox, LabeledInput } from './input'
 import { FormProvider, useForm } from 'react-hook-form'
 import { PagerContext } from './pager'
-import { Else, If, Then } from 'react-if'
+import { field, Fields } from './Fields'
 
 const Questions = (): ReactElement => {
   const information = useSelector((state: TaxesState) => state.information)
@@ -43,6 +42,8 @@ const Questions = (): ReactElement => {
     onAdvance()
   }
 
+  const questionFields = questions.map((q) => field(q.text, q.tag, undefined, q.valueTag === 'boolean' ? 'checkbox' : 'text'))
+
   const page = (
     <PagerContext.Consumer>
       { ({ onAdvance, navButtons }) =>
@@ -51,16 +52,9 @@ const Questions = (): ReactElement => {
           <p>Based on your prior responses, reseponses to these questions are required.</p>
           <List>
             {
-              questions.map((q, i) =>
+              questionFields.map((field, i) =>
                 <ListItem key={i}>
-                  <If condition={q.valueTag === 'boolean'}>
-                    <Then>
-                      <LabeledCheckbox name={q.tag} label={q.text} />
-                    </Then>
-                    <Else>
-                      <LabeledInput name={q.tag} label={q.text} />
-                    </Else>
-                  </If>
+                  <Fields fields={[field]} />
                 </ListItem>
               )
             }

--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -1,12 +1,13 @@
 import React, { ReactElement } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
-import { LabeledInput, LabeledRadio } from './input'
+import { LabeledRadio } from './input'
 import { Patterns } from './Patterns'
 import { saveRefundInfo } from '../redux/actions'
 
 import { AccountType, Refund, TaxesState } from '../redux/data'
 import { PagerContext } from './pager'
+import { field, FieldDef, Fields } from './Fields'
 
 interface UserRefundForm {
   routingNumber: string
@@ -15,6 +16,11 @@ interface UserRefundForm {
 }
 
 const toRefund = (formData: UserRefundForm): Refund => formData
+
+const fields: FieldDef[] = [
+  field('Bank Routing number', 'routingNumber', Patterns.bankRouting),
+  field('Bank Account number', 'accountNumber', Patterns.bankAccount)
+]
 
 export default function RefundBankAccount (): ReactElement {
   const defaultValues: Refund | undefined = useSelector((state: TaxesState) => {
@@ -39,22 +45,13 @@ export default function RefundBankAccount (): ReactElement {
           <FormProvider {...methods}>
             <h2>Refund Information</h2>
 
-            <LabeledInput
-              label="Bank Routing number"
-              patternConfig={Patterns.bankRouting}
-              name="routingNumber"
-            />
-
-            <LabeledInput
-              label="Bank Account number"
-              patternConfig={Patterns.bankAccount}
-              name="accountNumber"
-            />
-            <LabeledRadio
-              label="Account Type"
-              name="accountType"
-              values={[['Checking', 'checking'], ['Savings', 'savings']]}
-            />
+            <Fields fields={fields}>
+              <LabeledRadio
+                label="Account Type"
+                name="accountType"
+                values={[['Checking', 'checking'], ['Savings', 'savings']]}
+              />
+            </Fields>
             {navButtons}
           </FormProvider>
         </form>

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,14 +1,29 @@
-import React, { Fragment, ReactElement } from 'react'
+import React, { ReactElement } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { If } from 'react-if'
-import { LabeledCheckbox, LabeledInput, USStateDropDown } from '../input'
-import { CountryDropDown } from '../input/LabeledDropdown'
+import { field, Fields } from '../Fields'
 import { Patterns } from '../Patterns'
 
 interface AddressProps {
   checkboxText: string
   allowForeignCountry?: boolean
 }
+
+const domesticFields = [
+  field('State', 'address.state', undefined, 'state'),
+  field('Zip', 'address.zip', Patterns.zip)
+]
+
+const foreignFields = [
+  field('Province', 'address.province', Patterns.name),
+  field('Postal Code', 'address.postalCode'),
+  field('Country', 'address.foreignCountry', undefined, 'country')
+]
+
+const mainFields = [
+  field('Address', 'address.address', undefined, 'text', true),
+  field('Unit No', 'address.aptNo', undefined, 'text', false),
+  field('City', 'address.city', Patterns.name)
+]
 
 export default function AddressFields (props: AddressProps): ReactElement {
   const {
@@ -23,66 +38,13 @@ export default function AddressFields (props: AddressProps): ReactElement {
     control
   })
 
-  const csz: ReactElement = (() => {
-    if (!allowForeignCountry || !isForeignCountry) {
-      return (
-        <Fragment>
-          <USStateDropDown
-            label="State"
-            name="address.state"
-            required={!isForeignCountry}
-          />
-          <LabeledInput
-            label="Zip"
-            name="address.zip"
-            patternConfig={Patterns.zip}
-            required={!isForeignCountry}
-          />
-        </Fragment>
-      )
-    }
-    return (
-      <Fragment>
-        <LabeledInput
-          label="Province"
-          name="address.province"
-          required={isForeignCountry}
-        />
-        <LabeledInput
-          name="address.postalCode"
-          label="Postal Code"
-          required={isForeignCountry}
-        />
-        <CountryDropDown
-          name="address.foreignCountry"
-          label="Country"
-          required={isForeignCountry}
-        />
-      </Fragment>
-    )
-  })()
+  const foreignCountryField = field(checkboxText, 'isForeignCountry', undefined, 'checkbox')
 
   return (
-    <Fragment>
-      <LabeledInput
-        label="Address"
-        name="address.address"
-        required={true}
-      />
-      <LabeledInput
-        label="Unit No"
-        name="address.aptNo"
-        required={false}
-      />
-      <LabeledInput
-        label="City"
-        name="address.city"
-        patternConfig={Patterns.name}
-      />
-      <If condition={allowForeignCountry}>
-        <LabeledCheckbox label={checkboxText} name="isForeignCountry" />
-      </If>
-      {csz}
-    </Fragment>
+    <Fields fields={[
+      ...mainFields,
+      ...(allowForeignCountry ? [foreignCountryField] : []),
+      ...(!allowForeignCountry || !isForeignCountry ? domesticFields : foreignFields)
+    ]} />
   )
 }

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -1,11 +1,16 @@
 import React, { ReactElement } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
-import { LabeledInput } from '../input'
 import { Patterns } from '../Patterns'
 import { saveContactInfo } from '../../redux/actions'
 import { ContactInfo as Contact, TaxesState, TaxPayer } from '../../redux/data'
 import { PagerContext } from '../pager'
+import { field, Fields } from '../Fields'
+
+const fields = [
+  field('Contact phone number', 'contactPhoneNumber', Patterns.usPhoneNumber),
+  field('Contact email address', 'contactEmail', undefined, 'text', true)
+]
 
 export default function ContactInfo (): ReactElement {
   // const variable dispatch to allow use inside function
@@ -28,16 +33,7 @@ export default function ContactInfo (): ReactElement {
       { ({ navButtons, onAdvance }) =>
         <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
           <h2>Family Contact Information</h2>
-          <LabeledInput
-            label="Contact phone number"
-            patternConfig={Patterns.usPhoneNumber}
-            name="contactPhoneNumber"
-          />
-          <LabeledInput
-            label="Contact email address"
-            required={true}
-            name="contactEmail"
-          />
+          <Fields fields={fields} />
           {navButtons}
         </form>
       }

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -1,7 +1,7 @@
-import React, { Fragment, PropsWithChildren, ReactElement } from 'react'
+import React, { PropsWithChildren, ReactElement } from 'react'
 import { IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
-import { formatSSID, LabeledInput } from '../input'
+import { formatSSID } from '../input'
 import { Patterns } from '../Patterns'
 import { Actions, removeDependent } from '../../redux/actions'
 import { TaxesState, Person } from '../../redux/data'
@@ -10,26 +10,18 @@ import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
 import { If } from 'react-if'
+import { field, Fields } from '../Fields'
+
+export const personFields = [
+  field('First Name and Initial', 'firstName', Patterns.name),
+  field('Last Name', 'lastName', Patterns.name),
+  field('SSN / TIN', 'ssid', Patterns.ssn)
+]
 
 export const PersonFields = ({ children }: PropsWithChildren<{}>): ReactElement => (
-  <Fragment>
-    <LabeledInput
-      label="First Name and Initial"
-      name="firstName"
-      patternConfig={Patterns.name}
-    />
-    <LabeledInput
-      label="Last Name"
-      name="lastName"
-      patternConfig={Patterns.name}
-    />
-    <LabeledInput
-      label="SSN / TIN"
-      name="ssid"
-      patternConfig={Patterns.ssn}
-    />
+  <Fields fields={personFields}>
     {children}
-  </Fragment>
+  </Fields>
 )
 
 interface PersonListItemProps {

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -3,13 +3,14 @@ import React, { ReactElement, useState } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { Patterns } from '../Patterns'
-import { LabeledInput, LabeledCheckbox, formatSSID, GenericLabeledDropdown } from '../input'
+import { formatSSID, GenericLabeledDropdown } from '../input'
 import { TaxesState, TaxPayer, Dependent, Spouse, PersonRole, FilingStatus, FilingStatusTexts, filingStatuses } from '../../redux/data'
 import { addDependent, addSpouse, editDependent, removeDependent, removeSpouse, saveFilingStatusInfo } from '../../redux/actions'
 import { PersonFields } from './PersonFields'
 import { FormListContainer } from '../FormContainer'
 import { PagerContext } from '../pager'
 import { Person } from '@material-ui/icons'
+import { field, Fields } from '../Fields'
 
 interface UserPersonForm {
   firstName: string
@@ -23,6 +24,15 @@ interface UserDependentForm extends UserPersonForm {
   isStudent: boolean
   numberOfMonths: string
 }
+
+const fields = [
+  field('Relationship to Taxpayer', 'relationship', Patterns.name),
+  field('Birth Year', 'birthYear', Patterns.year),
+  field('How many months did you live together this year?', 'numberOfMonths', Patterns.numMonths),
+  field('Is this person a full-time student?', 'isStudent', undefined, 'checkbox')
+]
+
+const spouseDependent = field('Check if your spouse is a dependent', 'isTaxpayerDependent', undefined, 'checkbox')
 
 const toDependent = (formData: UserDependentForm): Dependent => {
   const { birthYear, numberOfMonths, isStudent, ...rest } = formData
@@ -106,25 +116,7 @@ export const AddDependentForm = (): ReactElement => {
       removeItem={(i) => dispatch(removeDependent(i))}
     >
       <PersonFields />
-      <LabeledInput
-        label="Relationship to Taxpayer"
-        name="relationship"
-        patternConfig={Patterns.name}
-      />
-      <LabeledInput
-        label="Birth Year"
-        patternConfig={Patterns.year}
-        name="birthYear"
-      />
-      <LabeledInput
-        label="How many months did you live together this year?"
-        patternConfig={Patterns.numMonths}
-        name="numberOfMonths"
-      />
-      <LabeledCheckbox
-        label="Is this person a full-time student?"
-        name="isStudent"
-      />
+      <Fields fields={fields} />
     </FormListContainer>
   )
 
@@ -173,10 +165,7 @@ export const SpouseInfo = (): ReactElement => {
       removeItem={() => dispatch(removeSpouse)}
     >
       <PersonFields>
-        <LabeledCheckbox
-          label="Check if your spouse is a dependent"
-          name="isTaxpayerDependent"
-        />
+        <Fields fields={[spouseDependent]} />
       </PersonFields>
     </FormListContainer>
   )

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -4,10 +4,11 @@ import SchoolIcon from '@material-ui/icons/School'
 import { useDispatch, useSelector } from 'react-redux'
 import { add1098e, edit1098e, remove1098e } from '../../redux/actions'
 import { PagerContext } from '../pager'
-import { Currency, LabeledInput } from '../input'
+import { Currency } from '../input'
 import { TaxesState, F1098e } from '../../redux/data'
 import { Patterns } from '../Patterns'
 import { FormListContainer } from '../FormContainer'
+import { field, FieldDef, Fields } from '../Fields'
 
 const showInterest = (a: F1098e): ReactElement => {
   return <Currency value={a.interest} />
@@ -35,6 +36,11 @@ const toF1098e = (f: F1098EUserInput): F1098e => {
     interest: Number(f.interest)
   }
 }
+
+const fields: FieldDef[] = [
+  field('Enter name of Lender', 'lender', Patterns.name),
+  field('Student Interest Paid', 'interest', Patterns.currency)
+]
 
 export default function F1098eInfo (): ReactElement {
   const f1098es = useSelector((state: TaxesState) =>
@@ -86,16 +92,7 @@ export default function F1098eInfo (): ReactElement {
       icon={(f) => <SchoolIcon />}
     >
       <strong>Input data from 1098-E</strong>
-      <LabeledInput
-        label="Enter name of Lender"
-        patternConfig={Patterns.name}
-        name="lender"
-      />
-      <LabeledInput
-        label="Student Interest Paid"
-        patternConfig={Patterns.currency}
-        name="interest"
-      />
+      <Fields fields={fields} />
     </FormListContainer>
   )
 

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { FormProvider, useForm } from 'react-hook-form'
 import { PagerContext } from '../pager'
 import { TaxesState, IncomeW2, Person, PersonRole, Employer, Spouse, PrimaryPerson, FilingStatus } from '../../redux/data'
-import { Currency, formatSSID, GenericLabeledDropdown, LabeledInput } from '../input'
+import { Currency, formatSSID, GenericLabeledDropdown } from '../input'
 import { Patterns } from '../Patterns'
 import { FormListContainer } from '../FormContainer'
 import { Box } from '@material-ui/core'
@@ -11,6 +11,7 @@ import { Work } from '@material-ui/icons'
 import { addW2, editW2, removeW2 } from '../../redux/actions'
 import { If } from 'react-if'
 import { Alert } from '@material-ui/lab'
+import { field, FieldDef, Fields } from '../Fields'
 
 interface IncomeW2UserInput {
   employer?: Employer
@@ -40,6 +41,15 @@ const toIncomeW2UserInput = (data: IncomeW2): IncomeW2UserInput => ({
   ssWithholding: data.ssWithholding.toString(),
   medicareWithholding: data.medicareWithholding.toString()
 })
+
+const fields: FieldDef[] = [
+  field('Employer name', 'employer.employerName', Patterns.name),
+  field('Occupation', 'occupation', Patterns.name),
+  field('Wages, tips, other compensation', 'income', Patterns.currency, 'text', undefined, 'Box 1 - '),
+  field('Federal income tax withheld', 'fedWithholding', Patterns.currency, 'text', undefined, 'Box 2 -'),
+  field('Social security tax withheld', 'ssWithholding', Patterns.currency, 'text', undefined, 'Box 4 - '),
+  field('Medicare tax withheld', 'medicareWithholding', Patterns.currency, 'text', undefined, 'Box 6 - ')
+]
 
 export default function W2JobInfo (): ReactElement {
   const dispatch = useDispatch()
@@ -106,45 +116,7 @@ export default function W2JobInfo (): ReactElement {
       max={omitAdd ? 0 : undefined}
     >
       <strong>Input data from W-2</strong>
-      <LabeledInput
-        label="Employer name"
-        patternConfig={Patterns.name}
-        name="employer.employerName"
-      />
-      <LabeledInput
-        label="Occupation"
-        patternConfig={Patterns.name}
-        name="occupation"
-      />
-
-      <LabeledInput
-        strongLabel="Box 1 - "
-        label="Wages, tips, other compensation"
-        patternConfig={Patterns.currency}
-        name="income"
-      />
-
-      <LabeledInput
-        strongLabel="Box 2 - "
-        label="Federal income tax withheld"
-        name="fedWithholding"
-        patternConfig={Patterns.currency}
-      />
-
-      <LabeledInput
-        strongLabel="Box 4 - "
-        label="Social security tax withheld"
-        name="ssWithholding"
-        patternConfig={Patterns.currency}
-      />
-
-      <LabeledInput
-        strongLabel="Box 6 - "
-        label="Medicare tax withheld"
-        name="medicareWithholding"
-        patternConfig={Patterns.currency}
-      />
-
+      <Fields fields={fields} />
       <GenericLabeledDropdown
         dropDownData={people}
         label="Employee"


### PR DESCRIPTION
Since we will have many many form fields, it might make more sense from here on to represent the form fields as a data structure instead of defining each individually in JSX. This may lead to benefits later, but for now it's at least more concise.

We might be able to expand on this a bit by including validation and model update logic in the field definitions, so that instead of each form requiring its own fully fleshed out functional react component, each field could exist independently. I think as our model data needs grow, the multi-page layout we have now might become a bit unwieldy and daunting for users. So this is a step in the direction of thinking about each piece of required data as a self contained entity rather than part of a form page.

For now, if the tradeoffs of this step seem beneficial, then we can explore ways to build on the idea later.

The main benefit for now is probably conciseness, which is really not much benefit at all if it reduces readability. So I'm proposing this idea just for comments!