### PR TITLE
Add sequence index information for each form

### DIFF
--- a/src/irsForms/F1040.ts
+++ b/src/irsForms/F1040.ts
@@ -35,6 +35,7 @@ export enum F1040Error {
 
 export default class F1040 implements Form {
   tag: FormTag = 'f1040'
+  sequenceIndex: number = 0
   // intentionally mirroring many fields from the state,
   // trying to represent the fields that the 1040 requires
   filingStatus?: FilingStatus

--- a/src/irsForms/F1040v.ts
+++ b/src/irsForms/F1040v.ts
@@ -4,6 +4,7 @@ import Form, { FormTag } from './Form'
 
 export default class F1040V implements Form {
   tag: FormTag = 'f1040v'
+  sequenceIndex: number = -1
   state: Information
   f1040: F1040
 

--- a/src/irsForms/F8959.ts
+++ b/src/irsForms/F8959.ts
@@ -16,6 +16,7 @@ export const needsF8959 = (state: Information): boolean => {
 
 export default class F8959 implements Form {
   tag: FormTag = 'f8959'
+  sequenceIndex: number = 71
   state: Information
   f4137?: F4137
   f8919?: F8919

--- a/src/irsForms/Form.ts
+++ b/src/irsForms/Form.ts
@@ -18,6 +18,10 @@ export type FormTag =
   *
   */
 export default interface Form {
+
+  // Match the filename without extension when downloaded from IRS
   tag: FormTag
+  // Match the sequence number in the header of the PDF.
+  sequenceIndex: number
   fields: () => Array<string | number | boolean | undefined>
 }

--- a/src/irsForms/Main.ts
+++ b/src/irsForms/Main.ts
@@ -16,25 +16,24 @@ import StudentLoanInterestWorksheet from './worksheets/StudentLoanInterestWorksh
 import Schedule2 from './Schedule2'
 
 export const getSchedules = (f1040: F1040, state: Information): Form[] => {
-  let attachments: Form[] = []
-  const prepends: Form[] = []
+  const forms: Form[] = [f1040]
 
   if (state.f1099s.find((v) => v.type === Income1099Type.INT) !== undefined) {
     const schB = new ScheduleB(state)
     f1040.addScheduleB(schB)
-    attachments = [...attachments, schB]
+    forms.push(schB)
   }
 
   if (state.f1099s.find((v) => v.type === Income1099Type.B) !== undefined) {
     const schD = new ScheduleD(state)
     f1040.addScheduleD(schD)
-    attachments = [...attachments, schD]
+    forms.push(schD)
   }
 
   if (state.realEstate.length > 0) {
     const se = new ScheduleE(state)
     f1040.addScheduleE(se)
-    attachments = [...attachments, se]
+    forms.push(se)
   }
 
   if (state.f1098es.length > 0) {
@@ -45,7 +44,7 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
     if (f1040.schedule1 === undefined && studentLoanInterestWorksheet.notMFS() && studentLoanInterestWorksheet.isNotDependent()) {
       const s1 = new Schedule1(state, f1040)
       f1040.addSchedule1(s1)
-      attachments = [s1, ...attachments]
+      forms.push(s1)
     }
   }
 
@@ -55,13 +54,14 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
 
     const s2 = f1040.schedule2 !== undefined ? f1040.schedule2 : new Schedule2(state.taxPayer, f8959)
     f1040.addSchedule2(s2)
-    attachments = [...attachments, s2, f8959]
+    forms.push(s2)
+    forms.push(f8959)
   }
 
   if (claimableExcessSSTaxWithholding(state.w2s) > 0 && f1040.schedule3 === undefined) {
     const s3 = new Schedule3(state, f1040)
     f1040.addSchedule3(s3)
-    attachments = [...attachments, s3]
+    forms.push(s3)
   }
 
   if (f1040.scheduleE !== undefined) {
@@ -69,7 +69,7 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
       const s1 = new Schedule1(state, f1040)
       f1040.addSchedule1(s1)
       s1.addScheduleE(f1040.scheduleE)
-      attachments = [s1, ...attachments]
+      forms.push(s1)
     } else {
       f1040.schedule1.addScheduleE(f1040.scheduleE)
     }
@@ -78,7 +78,7 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
   const eic = new ScheduleEIC(state.taxPayer, f1040)
   if (eic.allowed(f1040)) {
     f1040.addScheduleEIC(eic)
-    attachments = [...attachments, eic]
+    forms.push(eic)
   }
 
   const ws = new ChildTaxCreditWorksheet(f1040)
@@ -87,16 +87,17 @@ export const getSchedules = (f1040: F1040, state: Information): Form[] => {
   if (f1040.dependents.some((dep) => ws.qualifiesChild(dep) || ws.qualifiesOther(dep))) {
     f1040.addChildTaxCreditWorksheet(ws)
     f1040.addSchedule8812(schedule8812)
-    attachments = [...attachments, schedule8812]
+    forms.push(schedule8812)
   }
 
   // Attach payment voucher to front if there is a payment due
   if ((f1040.l37() ?? 0) > 0) {
-    const f1040v = new F1040V(state, f1040)
-    prepends.push(f1040v)
+    forms.push(new F1040V(state, f1040))
   }
 
-  return [...prepends, f1040, ...attachments]
+  forms.sort((a, b) => a.sequenceIndex - b.sequenceIndex)
+
+  return forms
 }
 
 export function create1040 (state: Information): Either<F1040Error[], [F1040, Form[]]> {

--- a/src/irsForms/Schedule1.ts
+++ b/src/irsForms/Schedule1.ts
@@ -11,6 +11,7 @@ const unimplemented = (message: string): void =>
 
 export default class Schedule1 implements Form {
   tag: FormTag = 'f1040s1'
+  sequenceIndex = 1
   state: Information
   scheduleE?: ScheduleE
   f1040: F1040

--- a/src/irsForms/Schedule2.ts
+++ b/src/irsForms/Schedule2.ts
@@ -6,6 +6,7 @@ import F8959 from './F8959'
 
 export default class Schedule2 implements Form {
   tag: FormTag = 'f1040s2'
+  sequenceIndex: number = 2
   tp: TaxPayer
   f8959?: F8959
 

--- a/src/irsForms/Schedule3.ts
+++ b/src/irsForms/Schedule3.ts
@@ -24,6 +24,7 @@ export const claimableExcessSSTaxWithholding = (w2s: IncomeW2[]): number => {
 
 export default class Schedule3 implements Form {
   tag: FormTag = 'f1040s3'
+  sequenceIndex: number = 3
   state: Information
   f1040: F1040
 

--- a/src/irsForms/Schedule8812.ts
+++ b/src/irsForms/Schedule8812.ts
@@ -8,6 +8,7 @@ export default class Schedule8812 implements Form {
   tp: TaxPayer
   f1040: F1040
   tag: FormTag = 'f1040s8'
+  sequenceIndex: number = 47
 
   constructor (tp: TP, f1040: F1040) {
     this.tp = new TaxPayer(tp)

--- a/src/irsForms/ScheduleB.ts
+++ b/src/irsForms/ScheduleB.ts
@@ -11,6 +11,7 @@ interface PayerAmount {
 
 export default class ScheduleB implements Form {
   tag: FormTag = 'f1040sb'
+  sequenceIndex: number = 8
   state: Information
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16

--- a/src/irsForms/ScheduleD.ts
+++ b/src/irsForms/ScheduleD.ts
@@ -14,6 +14,7 @@ import SDUnrecaptured1250 from './worksheets/SDUnrecaptured1250'
 
 export default class ScheduleD implements Form {
   tag: FormTag = 'f1040sd'
+  sequenceIndex: number = 12
   state: Information
   aggregated: F1099BData
   rateGainWorksheet: SDRateGainWorksheet

--- a/src/irsForms/ScheduleE.ts
+++ b/src/irsForms/ScheduleE.ts
@@ -39,6 +39,7 @@ const propTypeIndex = {
 
 export default class ScheduleE implements Form {
   tag: FormTag = 'f1040se'
+  sequenceIndex: number = 13
   state: Information
   f6168: F6168
   f8582: F8582

--- a/src/irsForms/ScheduleEIC.ts
+++ b/src/irsForms/ScheduleEIC.ts
@@ -42,6 +42,7 @@ const precludesEIC = <F>(p: PrecludesEIC<F>) => (f: F | undefined): boolean => {
 
 export default class ScheduleEIC implements Form {
   tag: FormTag = 'f1040sei'
+  sequenceIndex: number = 43
   tp: TaxPayer
   f2555?: F2555
   f4797?: F4797

--- a/src/tests/f1040.test.ts
+++ b/src/tests/f1040.test.ts
@@ -3,7 +3,7 @@ import { create1040 } from '../irsForms/Main'
 import { isRight } from '../util'
 import * as arbitraries from './arbitraries'
 
-describe('f1040', () =>
+describe('f1040', () => {
   it('should be created in', () => {
     fc.assert(
       fc.property(arbitraries.information,
@@ -21,4 +21,29 @@ describe('f1040', () =>
       )
     )
   })
-)
+
+  it('should not create duplicate schedules in', () => {
+    fc.assert(
+      fc.property(arbitraries.information, (information) => {
+        const f1040Res = create1040(information)
+        if (isRight(f1040Res)) {
+          const [, forms] = f1040Res.right
+          expect(new Set(forms.map((a) => a.tag)).size).toEqual(forms.length)
+          expect(new Set(forms.map((a) => a.sequenceIndex)).size).toEqual(forms.length)
+        }
+      })
+    )
+  })
+
+  it('should arrange attachments according to sequence order', () => {
+    fc.assert(
+      fc.property(arbitraries.information, (information) => {
+        const f1040Res = create1040(information)
+        if (isRight(f1040Res)) {
+          const [, forms] = f1040Res.right
+          expect(forms.sort((a, b) => a.sequenceIndex - b.sequenceIndex)).toEqual(forms)
+        }
+      })
+    )
+  })
+})


### PR DESCRIPTION
This lets us arrange the forms in the order IRS expects according to the sequence order number at the top of the PDF.