### PR TITLE
Add relative path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,11 +24,5 @@ module.exports = {
   plugins: [
     'react',
     '@typescript-eslint'
-  ],
-  rules: {
-    // proptypes validation as warnings for now
-    // in js defining extra prop types is a little
-    // cumbersome. Remember to remove if we switch to TS
-    'react/prop-types': 1
-  }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "src/customTypes",
       "node_modules/@types"
     ],
+    "baseUrl": "src",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Allows project to use src as relative path. For example, instead of './component/', you can use 'component/'