### PR TITLE
Fix default form values to fix validation error

### DIFF
--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -24,6 +24,21 @@ interface TaxPayerUserForm {
   isTaxpayerDependent: boolean
 }
 
+const defaultTaxpayerUserForm: TaxPayerUserForm = {
+  firstName: '',
+  lastName: '',
+  ssid: '',
+  role: PersonRole.PRIMARY,
+  isForeignCountry: false,
+  address: {
+    address: '',
+    city: '',
+    state: '',
+    zip: ''
+  },
+  isTaxpayerDependent: false
+}
+
 const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
   address: formData.address,
   firstName: formData.firstName,
@@ -51,11 +66,14 @@ export default function PrimaryTaxpayer(): ReactElement {
   })
 
   const methods = useForm<TaxPayerUserForm>({
-    defaultValues:
-      taxPayer.primaryPerson !== undefined
+    defaultValues: {
+      ...defaultTaxpayerUserForm,
+      ...(taxPayer.primaryPerson !== undefined
         ? asTaxPayerUserForm(taxPayer.primaryPerson)
-        : undefined
+        : {})
+    }
   })
+
   const { handleSubmit } = methods
 
   const onSubmit =


### PR DESCRIPTION
Without this, starting with empty data, a console log validation error shows isTaxpayerDependent field is missing:

![image](https://user-images.githubusercontent.com/1987109/130305526-9799458e-a76e-4d17-952c-e1d051ccae67.png)


