### PR TITLE
Deduplicate list add/edit functions for editable list forms

### DIFF
--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -17,6 +17,11 @@ import {
 import { red } from '@material-ui/core/colors'
 import { Delete, Edit } from '@material-ui/icons'
 import { Else, If, Then } from 'react-if'
+import {
+  SubmitHandler,
+  UnpackNestedValue,
+  useFormContext
+} from 'react-hook-form'
 
 interface FormContainerProps {
   onDone: () => void
@@ -121,11 +126,10 @@ export const MutableListItem = ({
 }
 
 interface FormListContainerProps<A> {
-  onDone: (f: () => void) => () => void
-  onCancel: () => void
+  onSubmitAdd: SubmitHandler<A>
+  onSubmitEdit: (index: number) => SubmitHandler<A>
+  onCancel?: () => void
   items: A[]
-  editItem?: (v: number) => void
-  editing?: number
   disableEditing?: boolean
   removeItem?: (v: number) => void
   primary: (a: A) => string
@@ -148,7 +152,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-const FormListContainer = <A extends object>(
+const FormListContainer = <A extends Record<string, any>>(
   props: PropsWithChildren<FormListContainerProps<A>>
 ): ReactElement => {
   const classes = useStyles()
@@ -159,35 +163,46 @@ const FormListContainer = <A extends object>(
     max,
     primary,
     secondary,
-    editItem,
-    editing,
     disableEditing = false,
     removeItem,
-    onDone,
-    onCancel
+    onSubmitAdd,
+    onSubmitEdit,
+    onCancel = () => {}
   } = props
   const [formState, setFormState] = useState(FormState.Closed)
 
+  const [editing, setEditing] = useState<number | undefined>(undefined)
+
   const close = (): void => {
     setFormState(FormState.Closed)
+    reset({ values: undefined })
+    setEditing(undefined)
   }
 
-  const _onCancel = (): void => {
+  // Note useFormContext here instead of useForm reuses the
+  // existing form context from the parent.
+  const { reset, handleSubmit } = useFormContext()
+
+  const onClose = (): void => {
     onCancel()
     close()
   }
 
-  const _onDone: () => void = onDone(close)
+  const onSave: SubmitHandler<A> = (formData): void => {
+    if (editing !== undefined) {
+      onSubmitEdit(editing)(formData)
+    } else {
+      onSubmitAdd(formData)
+    }
+    close()
+  }
 
-  const editAction = (() => {
-    if (
-      editItem !== undefined &&
-      !disableEditing &&
-      formState === FormState.Closed
-    ) {
+  const openEditForm = (() => {
+    if (!disableEditing && formState === FormState.Closed) {
       return (n: number) => () => {
         setFormState(FormState.Editing)
-        editItem(n)
+        setEditing(n)
+        reset(items[n])
       }
     }
     return () => undefined
@@ -202,7 +217,7 @@ const FormListContainer = <A extends object>(
               key={i}
               primary={primary(item)}
               secondary={secondary !== undefined ? secondary(item) : undefined}
-              onEdit={editAction(i)}
+              onEdit={openEditForm(i)}
               editing={editing === i}
               remove={
                 removeItem !== undefined ? () => removeItem(i) : undefined
@@ -220,7 +235,7 @@ const FormListContainer = <A extends object>(
       {itemDisplay}
       <If condition={formState !== FormState.Closed}>
         <Then>
-          <FormContainer onDone={_onDone} onCancel={_onCancel}>
+          <FormContainer onDone={handleSubmit(onSave)} onCancel={onClose}>
             {children}
           </FormContainer>
         </Then>

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -39,52 +39,33 @@ const toF1098e = (f: F1098EUserInput): F1098e => {
 
 export default function F1098eInfo(): ReactElement {
   const f1098es = useSelector((state: TaxesState) => state.information.f1098es)
-  const [editing, setEditing] = useState<number | undefined>(undefined)
 
-  const defaultValues: F1098EUserInput = (() => {
-    if (editing !== undefined) {
-      return toUserInput(f1098es[editing])
-    }
-    return blankUserInput
-  })()
+  const defaultValues: F1098EUserInput = blankUserInput
 
   const { onAdvance, navButtons } = usePager()
 
   const methods = useForm<F1098EUserInput>({ defaultValues })
-  const { handleSubmit, reset } = methods
 
   const dispatch = useDispatch()
 
-  const clear = (): void => {
-    reset()
-    setEditing(undefined)
+  const onAdd1098e = (formData: F1098EUserInput): void => {
+    dispatch(add1098e(toF1098e(formData)))
   }
 
-  const onAdd1098e =
-    (onSuccess: () => void) =>
+  const onEdit1098e =
+    (index: number) =>
     (formData: F1098EUserInput): void => {
-      const payload = toF1098e(formData)
-      if (payload !== undefined) {
-        if (editing === undefined) {
-          dispatch(add1098e(payload))
-        } else {
-          dispatch(edit1098e({ index: editing, value: payload }))
-        }
-        clear()
-        onSuccess()
-      }
+      dispatch(edit1098e({ value: toF1098e(formData), index }))
     }
 
   const form: ReactElement | undefined = (
     <FormListContainer
-      onDone={(onSuccess) => handleSubmit(onAdd1098e(onSuccess))}
-      onCancel={clear}
-      items={f1098es}
+      onSubmitAdd={onAdd1098e}
+      onSubmitEdit={onEdit1098e}
+      items={f1098es.map((a) => toUserInput(a))}
       removeItem={(i) => dispatch(remove1098e(i))}
-      editing={editing}
-      editItem={setEditing}
       primary={(f) => f.lender}
-      secondary={(f) => showInterest(f)}
+      secondary={(f) => showInterest(toF1098e(f))}
       icon={(f) => <SchoolIcon />}
     >
       <p>

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -50,7 +50,7 @@ const showIncome = (a: Supported1099): ReactElement => {
           <br />
           Taxable Amount: <Currency value={a.form.taxableAmount} />
           <br />
-          Federal Income Tax Withweld:{' '}
+          Federal Income Tax Withheld:{' '}
           <Currency value={a.form.federalIncomeTaxWithheld} />
         </span>
       )
@@ -183,36 +183,26 @@ export default function F1099Info(): ReactElement {
   const [editing, doSetEditing] = useState<number | undefined>(undefined)
 
   const methods = useForm<F1099UserInput>()
-  const { handleSubmit, reset, watch, setValue } = methods
+  const { reset, watch, setValue } = methods
   const selectedType: Income1099Type | undefined = watch('formType')
 
   const dispatch = useDispatch()
 
   const { onAdvance, navButtons } = usePager()
 
-  const setEditing = (idx: number): void => {
-    reset(toUserInput(f1099s[idx]))
-    doSetEditing(idx)
+  const onSubmitAdd = (formData: F1099UserInput): void => {
+    const payload = toF1099(formData)
+    if (payload !== undefined) {
+      dispatch(add1099(payload))
+    }
   }
 
-  const clear = (): void => {
-    reset()
-    setValue('formType', undefined)
-    doSetEditing(undefined)
-  }
-
-  const onAdd1099 =
-    (onSuccess: () => void) =>
+  const onSubmitEdit =
+    (index: number) =>
     (formData: F1099UserInput): void => {
       const payload = toF1099(formData)
       if (payload !== undefined) {
-        if (editing === undefined) {
-          dispatch(add1099(payload))
-        } else {
-          dispatch(edit1099({ index: editing, value: payload }))
-        }
-        clear()
-        onSuccess()
+        dispatch(edit1099({ value: payload, index }))
       }
     }
 
@@ -343,17 +333,24 @@ export default function F1099Info(): ReactElement {
 
   const form: ReactElement | undefined = (
     <FormListContainer
-      onDone={(onSuccess) => handleSubmit(onAdd1099(onSuccess))}
-      onCancel={clear}
-      items={f1099s}
+      onSubmitAdd={onSubmitAdd}
+      onSubmitEdit={onSubmitEdit}
+      items={f1099s.map((a) => toUserInput(a))}
       removeItem={(i) => dispatch(remove1099(i))}
-      editing={editing}
-      editItem={setEditing}
       primary={(f) => f.payer}
-      secondary={(f) => showIncome(f)}
+      secondary={(f) => {
+        const form = toF1099(f)
+        if (form !== undefined) {
+          return showIncome(form)
+        }
+        return ''
+      }}
       icon={(f) => (
-        <Icon style={{ lineHeight: 1 }} title={titles[f.type]}>
-          {f.type}
+        <Icon
+          style={{ lineHeight: 1 }}
+          title={f.formType !== undefined ? titles[f.formType] : undefined}
+        >
+          {f.formType}
         </Icon>
       )}
     >


### PR DESCRIPTION
FormListContainer is improved so it handles all the form resetting when an edit button is clicked. The user now only has to supply simpler onEdit, onSave, onDelete functions. Editing state is maintained by the generic component.

FormListContainer also does `handleSubmit`'s error handling and resetting of the edit form.

Additional testing is not provided in this PR yet, but the existing SpouseAndDependent does serve as a specific implementation of the FormListContainer so (copout) it does increase coverage since we're using this component more generically.

Fixes #512

