### PR TITLE
Add back typescript-eslint/recommended

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+serviceWorker.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,9 @@ module.exports = {
     ecmaVersion: 12,
     sourceType: 'module'
   },
-  plugins: ['react', '@typescript-eslint', 'prettier']
+  plugins: ['react', '@typescript-eslint', 'prettier'],
+  rules: {
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off'
+  }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,15 +9,18 @@ module.exports = {
     es2021: true,
     node: true
   },
-  extends: ['plugin:react/recommended', 'prettier'],
+  extends: [
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
       jsx: true
     },
     ecmaVersion: 12,
-    sourceType: 'module',
-    project: './tsconfig.json'
+    sourceType: 'module'
   },
   plugins: ['react', '@typescript-eslint', 'prettier']
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//.npmrc file
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "node ./setup.js && craco build",
     "test": "node ./setup.js && craco test",
     "eject": "craco eject",
+    "test:report": "node ./setup.js && craco test -- --coverage",
     "desktop-release": "node ./setup.js && tauri build",
     "desktop": "node ./notice.js && node ./setup.js && tauri dev",
     "tauri": "tauri",
@@ -99,6 +100,12 @@
   "jest": {
     "moduleNameMapper": {
       "^ustaxes/(.*)": "<rootDir>/src/$1"
-    }
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@tauri-apps)"
+    ]
+  },
+  "engines": {
+    "yarn": "please-use-npm"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,24 +1,8 @@
-html {
-  overflow-y: scroll;
-  height: 100vh;
-}
-
 body {
   background-color: whitesmoke;
   height: 100vh;
 }
 
-/* Custom CSS */
-form {
-  border-radius: 5px;
-  box-shadow: rgba(0, 0, 0, 0.2) 0px 20px 30px;
-  background-color: white;
-  padding: 1em;
-  padding-left: 2em;
-  padding-right: 2em;
-}
-
-.inner {
-  margin-top: 1em;
-  padding: 1em, 2em, 0em, 2em;
+.MuiGrid-container ~ .MuiGrid-container {
+  margin-top: 8px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import Main from './components/Main'
 import './App.css'
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,10 @@
 import React, { ReactElement } from 'react'
 import Main from './components/Main'
 import './App.css'
-import { ViewportProvider } from './hooks/Viewport'
 
 const App = (): ReactElement => (
   <div className="App">
-    <ViewportProvider>
-      <Main />
-    </ViewportProvider>
+    <Main />
   </div>
 )
 

--- a/src/components/ConditionallyWrap.tsx
+++ b/src/components/ConditionallyWrap.tsx
@@ -1,9 +1,7 @@
-import React, {
-  PropsWithChildren,
-  FunctionComponent,
-  ReactElement
-} from 'react'
+import { PropsWithChildren, FunctionComponent, ReactElement } from 'react'
 
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const ConditionallyWrap = ({
   condition,
   wrapper,

--- a/src/components/ConditionallyWrap.tsx
+++ b/src/components/ConditionallyWrap.tsx
@@ -1,0 +1,17 @@
+import React, {
+  PropsWithChildren,
+  FunctionComponent,
+  ReactElement
+} from 'react'
+
+const ConditionallyWrap = ({
+  condition,
+  wrapper,
+  children
+}: PropsWithChildren<{
+  condition: boolean
+  wrapper: FunctionComponent<any>
+  children: ReactElement
+}>) => (condition ? wrapper(children) : children)
+
+export default ConditionallyWrap

--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, useState } from 'react'
+import { PropsWithChildren, ReactElement, useState } from 'react'
 import {
   createStyles,
   makeStyles,

--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -148,7 +148,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-const FormListContainer = <A extends object>(
+const FormListContainer = <A,>(
   props: PropsWithChildren<FormListContainerProps<A>>
 ): ReactElement => {
   const classes = useStyles()

--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -1,5 +1,7 @@
 import React, { PropsWithChildren, ReactElement, useState } from 'react'
 import {
+  createStyles,
+  makeStyles,
   IconButton,
   List,
   ListItem,
@@ -9,6 +11,7 @@ import {
   Box,
   Button,
   unstable_createMuiStrictModeTheme as createMuiTheme,
+  Theme,
   ThemeProvider
 } from '@material-ui/core'
 import { red } from '@material-ui/core/colors'
@@ -36,10 +39,10 @@ const FormContainer = ({
     <Box
       display="flex"
       justifyContent="flex-start"
-      paddingTop={2}
-      paddingBottom={1}
+      marginTop={2}
+      marginBottom={3}
     >
-      <Box paddingRight={2}>
+      <Box marginRight={2}>
         <Button
           type="button"
           onClick={onDone}
@@ -137,9 +140,18 @@ enum FormState {
   Closed
 }
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    buttonList: {
+      margin: `${theme.spacing(2)}px 0 ${theme.spacing(3)}px`
+    }
+  })
+)
+
 const FormListContainer = <A extends object>(
   props: PropsWithChildren<FormListContainerProps<A>>
 ): ReactElement => {
+  const classes = useStyles()
   const {
     children,
     items,
@@ -204,7 +216,7 @@ const FormListContainer = <A extends object>(
   })()
 
   return (
-    <div>
+    <>
       {itemDisplay}
       <If condition={formState !== FormState.Closed}>
         <Then>
@@ -214,18 +226,20 @@ const FormListContainer = <A extends object>(
         </Then>
         <Else>
           <If condition={max === undefined || items.length < max}>
-            <Button
-              type="button"
-              onClick={() => setFormState(FormState.Adding)}
-              variant="contained"
-              color="secondary"
-            >
-              Add
-            </Button>
+            <div className={classes.buttonList}>
+              <Button
+                type="button"
+                onClick={() => setFormState(FormState.Adding)}
+                variant="contained"
+                color="secondary"
+              >
+                Add
+              </Button>
+            </div>
           </If>
         </Else>
       </If>
-    </div>
+    </>
   )
 }
 

--- a/src/components/GettingStarted.tsx
+++ b/src/components/GettingStarted.tsx
@@ -1,14 +1,15 @@
 import React, { ReactElement } from 'react'
 import { StartButtons, SingleButtons } from './pager'
+import { isWeb } from 'ustaxes/util'
 
-const repoUrl: string = 'https://github.com/ustaxes/UsTaxes'
-const codeOfConductUrl: string =
+const repoUrl = 'https://github.com/ustaxes/UsTaxes'
+const codeOfConductUrl =
   'https://github.com/ustaxes/UsTaxes/blob/master/docs/CODE_OF_CONDUCT.md'
-const contributingUrl: string =
+const contributingUrl =
   'https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md'
-const architecture: string =
+const architecture =
   'https://github.com/ustaxes/UsTaxes/blob/master/docs/ARCHITECTURE.md'
-const releases: string = 'https://github.com/ustaxes/UsTaxes/releases'
+const releases = 'https://github.com/ustaxes/UsTaxes/releases'
 
 const doubleButtons: ReactElement = (
   <StartButtons
@@ -84,7 +85,7 @@ export default function GettingStarted(): ReactElement {
         able to use UsTaxes to paper file your return!
       </p>
 
-      {(window as any).__TAURI__ === undefined ? doubleButtons : singleButtons}
+      {isWeb() ? doubleButtons : singleButtons}
 
       <h2>About This Project</h2>
       <p>

--- a/src/components/GettingStarted.tsx
+++ b/src/components/GettingStarted.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { StartButtons, SingleButtons } from './pager'
 import { isWeb } from 'ustaxes/util'
 

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import {
   unstable_createMuiStrictModeTheme as createMuiTheme,
   ThemeProvider,

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,41 +1,23 @@
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement } from 'react'
 import {
   unstable_createMuiStrictModeTheme as createMuiTheme,
   ThemeProvider,
   makeStyles,
   createStyles,
   Theme,
-  AppBar,
-  Toolbar,
-  IconButton,
   Grid
 } from '@material-ui/core'
 import { Switch, Route, Redirect, useLocation } from 'react-router-dom'
-import MenuIcon from '@material-ui/icons/Menu'
-import W2JobInfo from './income/W2JobInfo'
-import CreatePDF from './createPDF'
-import ResponsiveDrawer, {
-  item,
-  Section,
-  SectionItem
-} from './ResponsiveDrawer'
-import { PagerButtons, PagerContext, PagerProvider, usePager } from './pager'
-import PrimaryTaxpayer from './TaxPayer'
-import RefundBankAccount from './RefundBankAccount'
-import SpouseAndDependent from './TaxPayer/SpouseAndDependent'
-import ContactInfo from './TaxPayer/ContactInfo'
-import F1099Info from './income/F1099Info'
-import Summary from './Summary'
-import RealEstate from './income/RealEstate'
-import GettingStarted from './GettingStarted'
-import F1098eInfo from './deductions/F1098eInfo'
+import { PagerProvider } from './pager'
 import { StateLoader } from './debug'
 import NoMatchPage from './NoMatchPage'
-import Questions from './Questions'
-import { useViewport } from '../hooks/Viewport'
-import { useEffect } from 'react'
+import Menu, { drawerSections } from './Menu'
+import { Section, SectionItem } from './ResponsiveDrawer'
 
-const theme = createMuiTheme({
+import { useDevice } from 'ustaxes/hooks/Device'
+import Urls from 'ustaxes/data/urls'
+
+export const theme = createMuiTheme({
   palette: {
     secondary: {
       light: '#4f5b62',
@@ -52,120 +34,43 @@ const theme = createMuiTheme({
   }
 })
 
-const useStyles = makeStyles((theme: Theme) =>
+type Props = {
+  isMobile: boolean
+}
+
+const useStyles = makeStyles<Theme, Props>((theme: Theme) =>
   createStyles({
-    appBar: {
-      width: '100%',
-      [theme.breakpoints.up('sm')]: {
-        display: 'none'
-      }
+    main: {
+      display: 'flex'
     },
-    menuButton: {
-      marginRight: theme.spacing(2),
+    content: ({ isMobile }) => ({
+      padding: '1em 2em',
+      backgroundColor: 'white',
       [theme.breakpoints.up('sm')]: {
-        display: 'none'
-      }
-    },
+        borderRadius: '5px',
+        boxShadow: 'rgba(0, 0, 0, 0.2) 0px 20px 30px',
+        margin: theme.spacing(3),
+        padding: '1em 2em'
+      },
+      width: isMobile ? '100%' : undefined
+    }),
     // necessary for content to be below app bar
     toolbar: {
       ...theme.mixins.toolbar,
       [theme.breakpoints.up('sm')]: {
         display: 'none'
       }
-    },
-    main: {
-      display: 'flex'
-    },
-    content: {
-      padding: theme.spacing(3)
     }
   })
 )
 
-const Urls = {
-  usTaxes: {
-    start: '/start'
-  },
-  taxPayer: {
-    root: '/taxpayer',
-    info: '/info',
-    spouseAndDependent: '/spouseanddependent',
-    contactInfo: '/contact'
-  },
-  refund: '/refundinfo',
-  questions: '/questions',
-  income: {
-    w2s: '/income/w2jobinfo',
-    f1099s: '/income/f1099s',
-    realEstate: '/income/realestate'
-  },
-  deductions: {
-    f1098es: '/deductions/studentloaninterest'
-  },
-  credits: {
-    main: '/credits',
-    eic: '/credits/eic'
-  },
-  createPdf: '/createpdf',
-  summary: '/summary',
-  default: ''
-}
-Urls.default = Urls.usTaxes.start
-
-const drawerSections: Section[] = [
-  {
-    title: 'UsTaxes.org',
-    items: [item('Getting Started', Urls.usTaxes.start, <GettingStarted />)]
-  },
-  {
-    title: 'Personal',
-    items: [
-      item('Primary Taxpayer', Urls.taxPayer.info, <PrimaryTaxpayer />),
-      item(
-        'Spouse and Dependents',
-        Urls.taxPayer.spouseAndDependent,
-        <SpouseAndDependent />
-      ),
-      item('Contact Information', Urls.taxPayer.contactInfo, <ContactInfo />)
-    ]
-  },
-  {
-    title: 'Income',
-    items: [
-      item('Wages (W2)', Urls.income.w2s, <W2JobInfo />),
-      item('Income (1099)', Urls.income.f1099s, <F1099Info />),
-      item('Real Estate', Urls.income.realEstate, <RealEstate />)
-    ]
-  },
-  {
-    title: 'Deductions',
-    items: [
-      item('Student Loan Interest', Urls.deductions.f1098es, <F1098eInfo />)
-    ]
-  },
-  {
-    title: 'Results',
-    items: [
-      item('Refund Information', Urls.refund, <RefundBankAccount />),
-      item('Informational Questions', Urls.questions, <Questions />),
-      item('Summary', Urls.summary, <Summary />),
-      item('Review and Print', Urls.createPdf, <CreatePDF />)
-    ]
-  }
-]
-
 export default function Main(): ReactElement {
-  const classes = useStyles()
-  const { width } = useViewport()
-  const [isMobile, setIsMobile] = useState(theme.breakpoints.values.sm > width)
+  const { isMobile } = useDevice()
+  const classes = useStyles({ isMobile })
 
   const allItems: SectionItem[] = drawerSections.flatMap(
     (section: Section) => section.items
   )
-
-  useEffect(() => {
-    setIsMobile(theme.breakpoints.values.sm > width)
-  }, [width])
 
   return (
     <ThemeProvider theme={theme}>
@@ -177,35 +82,9 @@ export default function Main(): ReactElement {
             <Redirect path="/" to={Urls.default} exact />
             {allItems.map((item, index) => (
               <Route key={index} exact path={item.url}>
-                {useLocation().pathname !== '/start' && (
-                  <>
-                    <AppBar position="fixed" className={classes.appBar}>
-                      <Toolbar>
-                        <IconButton
-                          color="inherit"
-                          aria-label="open drawer"
-                          edge="start"
-                          onClick={() => setIsMobile((isMobile) => !isMobile)}
-                          className={classes.menuButton}
-                        >
-                          <MenuIcon />
-                        </IconButton>
-                      </Toolbar>
-                    </AppBar>
-                    <ResponsiveDrawer
-                      sections={drawerSections}
-                      isOpen={!isMobile}
-                      onClose={() => setIsMobile((isMobile) => !isMobile)}
-                    />
-                  </>
-                )}
-                <Grid
-                  className={classes.content}
-                  container
-                  justifyContent="center"
-                  direction="row"
-                >
-                  <Grid item xs={12} lg={6}>
+                {useLocation().pathname !== '/start' && <Menu />}
+                <Grid container justifyContent="center" direction="row">
+                  <Grid item sm={12} md={8} lg={6} className={classes.content}>
                     {item.element}
                   </Grid>
                 </Grid>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -25,6 +25,7 @@ import F1098eInfo from './deductions/F1098eInfo'
 import Questions from './Questions'
 import Urls from 'ustaxes/data/urls'
 import { useDevice } from 'ustaxes/hooks/Device'
+import { ReactElement } from 'react'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -85,7 +86,7 @@ export const drawerSections: Section[] = [
   }
 ]
 
-const Menu = () => {
+const Menu = (): ReactElement => {
   const classes = useStyles()
   const { isMobile } = useDevice()
   const [isOpen, setOpen] = useState(!isMobile)

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react'
+import {
+  createStyles,
+  makeStyles,
+  AppBar,
+  IconButton,
+  Theme,
+  Toolbar
+} from '@material-ui/core'
+import MenuIcon from '@material-ui/icons/Menu'
+
+import ResponsiveDrawer, { item, Section } from './ResponsiveDrawer'
+
+import W2JobInfo from './income/W2JobInfo'
+import CreatePDF from './createPDF'
+import PrimaryTaxpayer from './TaxPayer'
+import RefundBankAccount from './RefundBankAccount'
+import SpouseAndDependent from './TaxPayer/SpouseAndDependent'
+import ContactInfo from './TaxPayer/ContactInfo'
+import F1099Info from './income/F1099Info'
+import Summary from './Summary'
+import RealEstate from './income/RealEstate'
+import GettingStarted from './GettingStarted'
+import F1098eInfo from './deductions/F1098eInfo'
+import Questions from './Questions'
+import Urls from 'ustaxes/data/urls'
+import { useDevice } from 'ustaxes/hooks/Device'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    appBar: {
+      width: '100%',
+      [theme.breakpoints.up('sm')]: {
+        display: 'none'
+      }
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        display: 'none'
+      }
+    }
+  })
+)
+
+export const drawerSections: Section[] = [
+  {
+    title: 'UsTaxes.org',
+    items: [item('Getting Started', Urls.usTaxes.start, <GettingStarted />)]
+  },
+  {
+    title: 'Personal',
+    items: [
+      item('Primary Taxpayer', Urls.taxPayer.info, <PrimaryTaxpayer />),
+      item(
+        'Spouse and Dependents',
+        Urls.taxPayer.spouseAndDependent,
+        <SpouseAndDependent />
+      ),
+      item('Contact Information', Urls.taxPayer.contactInfo, <ContactInfo />)
+    ]
+  },
+  {
+    title: 'Income',
+    items: [
+      item('Wages (W2)', Urls.income.w2s, <W2JobInfo />),
+      item('Income (1099)', Urls.income.f1099s, <F1099Info />),
+      item('Real Estate', Urls.income.realEstate, <RealEstate />)
+    ]
+  },
+  {
+    title: 'Deductions',
+    items: [
+      item('Student Loan Interest', Urls.deductions.f1098es, <F1098eInfo />)
+    ]
+  },
+  {
+    title: 'Results',
+    items: [
+      item('Refund Information', Urls.refund, <RefundBankAccount />),
+      item('Informational Questions', Urls.questions, <Questions />),
+      item('Summary', Urls.summary, <Summary />),
+      item('Review and Print', Urls.createPdf, <CreatePDF />)
+    ]
+  }
+]
+
+const Menu = () => {
+  const classes = useStyles()
+  const { isMobile } = useDevice()
+  const [isOpen, setOpen] = useState(!isMobile)
+
+  useEffect(() => {
+    if (!isMobile) {
+      setOpen(true)
+    } else {
+      setOpen(false)
+    }
+  }, [isMobile])
+
+  return (
+    <>
+      <AppBar position="fixed" className={classes.appBar}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={() => setOpen((isOpen) => !isOpen)}
+            className={classes.menuButton}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <ResponsiveDrawer
+        sections={drawerSections}
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  )
+}
+
+export default Menu

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   createStyles,
   makeStyles,

--- a/src/components/NoMatchPage.tsx
+++ b/src/components/NoMatchPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { SingleButtons } from './pager'
 
 export default function NoMatchPage(): ReactElement {

--- a/src/components/Patterns.ts
+++ b/src/components/Patterns.ts
@@ -133,7 +133,7 @@ export const Patterns = {
     'Input should be 10 digits, not starting with 0 or 1',
     undefined,
     undefined,
-    '(###)-###-####'
+    '(###) ###-####'
   ),
   plain: text(/.*/, '')
 }

--- a/src/components/Patterns.ts
+++ b/src/components/Patterns.ts
@@ -31,9 +31,9 @@ const numeric = (
   min: number | undefined = undefined,
   max: number | undefined = undefined,
   format: string | undefined = undefined,
-  mask: string = '_',
-  thousandSeparator: boolean = false,
-  prefix: string = '',
+  mask = '_',
+  thousandSeparator = false,
+  prefix = '',
   decimalScale: number | undefined = 0
 ): NumericPattern => ({
   inputType: 'numeric',

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { Grid, List, ListItem } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import {

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { List, ListItem } from '@material-ui/core'
+import { Grid, List, ListItem } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   getRequiredQuestions,
@@ -61,20 +61,22 @@ const Questions = (): ReactElement => {
         Based on your prior responses, reseponses to these questions are
         required.
       </p>
-      <List>
-        {questions.map((q, i) => (
-          <ListItem key={i}>
-            <If condition={q.valueTag === 'boolean'}>
-              <Then>
-                <LabeledCheckbox name={q.tag} label={q.text} />
-              </Then>
-              <Else>
-                <LabeledInput name={q.tag} label={q.text} />
-              </Else>
-            </If>
-          </ListItem>
-        ))}
-      </List>
+      <Grid container spacing={2}>
+        <List>
+          {questions.map((q, i) => (
+            <ListItem key={i}>
+              <If condition={q.valueTag === 'boolean'}>
+                <Then>
+                  <LabeledCheckbox name={q.tag} label={q.text} />
+                </Then>
+                <Else>
+                  <LabeledInput name={q.tag} label={q.text} />
+                </Else>
+              </If>
+            </ListItem>
+          ))}
+        </List>
+      </Grid>
       {navButtons}
     </form>
   )

--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -7,6 +7,7 @@ import { saveRefundInfo } from 'ustaxes/redux/actions'
 
 import { AccountType, Refund, TaxesState } from 'ustaxes/redux/data'
 import { usePager } from './pager'
+import { Grid } from '@material-ui/core'
 
 interface UserRefundForm {
   routingNumber: string
@@ -40,26 +41,27 @@ export default function RefundBankAccount(): ReactElement {
     <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
       <FormProvider {...methods}>
         <h2>Refund Information</h2>
+        <Grid container spacing={2}>
+          <LabeledInput
+            label="Bank Routing number"
+            patternConfig={Patterns.bankRouting}
+            name="routingNumber"
+          />
 
-        <LabeledInput
-          label="Bank Routing number"
-          patternConfig={Patterns.bankRouting}
-          name="routingNumber"
-        />
-
-        <LabeledInput
-          label="Bank Account number"
-          patternConfig={Patterns.bankAccount}
-          name="accountNumber"
-        />
-        <LabeledRadio
-          label="Account Type"
-          name="accountType"
-          values={[
-            ['Checking', 'checking'],
-            ['Savings', 'savings']
-          ]}
-        />
+          <LabeledInput
+            label="Bank Account number"
+            patternConfig={Patterns.bankAccount}
+            name="accountNumber"
+          />
+          <LabeledRadio
+            label="Account Type"
+            name="accountType"
+            values={[
+              ['Checking', 'checking'],
+              ['Savings', 'savings']
+            ]}
+          />
+        </Grid>
         {navButtons}
       </FormProvider>
     </form>

--- a/src/components/RefundBankAccount.tsx
+++ b/src/components/RefundBankAccount.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { LabeledInput, LabeledRadio } from './input'

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import Divider from '@material-ui/core/Divider'
 import Drawer from '@material-ui/core/Drawer'
 import List from '@material-ui/core/List'

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -4,34 +4,36 @@ import Drawer from '@material-ui/core/Drawer'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
-import { makeStyles, useTheme } from '@material-ui/core/styles'
+import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles'
 import { NavLink, useLocation } from 'react-router-dom'
-import { useViewport } from '../hooks/Viewport'
+import { useDevice } from 'ustaxes/hooks/Device'
 
 const drawerWidth = 240
 
-const useStyles = makeStyles((theme) => ({
-  drawer: {
-    [theme.breakpoints.up('sm')]: {
-      width: drawerWidth,
-      flexShrink: 0
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    drawer: {
+      [theme.breakpoints.up('sm')]: {
+        width: drawerWidth,
+        flexShrink: 0
+      }
+    },
+    drawerPaper: {
+      width: drawerWidth
+    },
+    list: {
+      marginLeft: theme.spacing(0),
+      paddingLeft: theme.spacing(0)
+    },
+    listItem: {
+      marginLeft: theme.spacing(0),
+      paddingLeft: theme.spacing(2)
+    },
+    sectionHeader: {
+      marginLeft: theme.spacing(2)
     }
-  },
-  drawerPaper: {
-    width: drawerWidth
-  },
-  list: {
-    marginLeft: theme.spacing(0),
-    paddingLeft: theme.spacing(0)
-  },
-  listItem: {
-    marginLeft: theme.spacing(0),
-    paddingLeft: theme.spacing(2)
-  },
-  sectionHeader: {
-    marginLeft: theme.spacing(2)
-  }
-}))
+  })
+)
 
 export interface SectionItem {
   title: string
@@ -61,13 +63,12 @@ export interface DrawerItemsProps {
 }
 
 function ResponsiveDrawer(props: DrawerItemsProps): ReactElement {
-  const { width } = useViewport()
+  const { isMobile } = useDevice()
   const location = useLocation()
   const classes = useStyles()
   const theme = useTheme()
 
   const { sections, isOpen, onClose } = props
-  const isMobile = theme.breakpoints.values.sm > width
 
   const drawer = (
     <>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement } from 'react'
+import { ReactElement } from 'react'
 import {
   List,
   ListItem,
@@ -120,13 +120,13 @@ const F1040Summary = ({ f1040 }: F1040Props): ReactElement => {
   )
 
   return (
-    <Fragment>
+    <>
       <h4>Credits</h4>
       <List>
         {earnedIncomeTaxCredit}
         {creditForChildrenAndOtherDependents}
       </List>
-    </Fragment>
+    </>
   )
 }
 
@@ -147,13 +147,13 @@ const Summary = (): ReactElement => {
         const errors = f1040Result.left
 
         return (
-          <Fragment>
+          <>
             {errors.map((error, i) => (
               <Alert key={i} severity="warning">
                 {error}
               </Alert>
             ))}
-          </Fragment>
+          </>
         )
       } else {
         const [f1040] = f1040Result.right

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react'
+import { Fragment, ReactElement } from 'react'
 import {
   List,
   ListItem,
@@ -72,7 +72,7 @@ const F1040Summary = ({ f1040 }: F1040Props): ReactElement => {
       <ListItemText
         primary="Earned Income Tax Credit"
         secondary={
-          <React.Fragment>
+          <>
             <Typography
               component="span"
               variant="body2"
@@ -95,7 +95,7 @@ const F1040Summary = ({ f1040 }: F1040Props): ReactElement => {
                 value={Math.round(f1040.scheduleEIC?.credit(f1040) ?? 0)}
               />
             </Typography>
-          </React.Fragment>
+          </>
         }
       />
     </BinaryStateListItem>
@@ -108,14 +108,12 @@ const F1040Summary = ({ f1040 }: F1040Props): ReactElement => {
       <ListItemText
         primary="Credit for children and other dependents"
         secondary={
-          <React.Fragment>
-            <Typography component="span" variant="body2" color="textPrimary">
-              Credit:{' '}
-              <Currency
-                value={Math.round(f1040.childTaxCreditWorksheet?.credit() ?? 0)}
-              />
-            </Typography>
-          </React.Fragment>
+          <Typography component="span" variant="body2" color="textPrimary">
+            Credit:{' '}
+            <Currency
+              value={Math.round(f1040.childTaxCreditWorksheet?.credit() ?? 0)}
+            />
+          </Typography>
         }
       />
     </BinaryStateListItem>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -67,8 +67,6 @@ interface F1040Props {
 const F1040Summary = ({ f1040 }: F1040Props): ReactElement => {
   const classes = useStyles()
 
-  const { navButtons, onAdvance } = usePager()
-
   const earnedIncomeTaxCredit = (
     <BinaryStateListItem active={f1040.scheduleEIC?.allowed(f1040) ?? false}>
       <ListItemText

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { If } from 'react-if'
 import {
@@ -30,7 +30,7 @@ export default function AddressFields(props: AddressProps): ReactElement {
   const csz: ReactElement = (() => {
     if (!allowForeignCountry || !isForeignCountry) {
       return (
-        <Fragment>
+        <>
           <USStateDropDown
             label="State"
             name="address.state"
@@ -42,11 +42,11 @@ export default function AddressFields(props: AddressProps): ReactElement {
             patternConfig={Patterns.zip}
             required={!isForeignCountry}
           />
-        </Fragment>
+        </>
       )
     }
     return (
-      <Fragment>
+      <>
         <LabeledInput
           label="Province"
           name="address.province"
@@ -62,12 +62,12 @@ export default function AddressFields(props: AddressProps): ReactElement {
           label="Country"
           required={isForeignCountry}
         />
-      </Fragment>
+      </>
     )
   })()
 
   return (
-    <Fragment>
+    <>
       <LabeledInput label="Address" name="address.address" required={true} />
       <LabeledInput label="Unit No" name="address.aptNo" required={false} />
       <LabeledInput
@@ -79,6 +79,6 @@ export default function AddressFields(props: AddressProps): ReactElement {
         <LabeledCheckbox label={checkboxText} name="isForeignCountry" />
       </If>
       {csz}
-    </Fragment>
+    </>
   )
 }

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react'
+import { Fragment, ReactElement } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { If } from 'react-if'
 import {

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -10,6 +10,7 @@ import {
   TaxPayer
 } from 'ustaxes/redux/data'
 import { usePager } from 'ustaxes/components/pager'
+import { Grid } from '@material-ui/core'
 
 export default function ContactInfo(): ReactElement {
   // const variable dispatch to allow use inside function
@@ -36,16 +37,18 @@ export default function ContactInfo(): ReactElement {
   const page = (
     <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
       <h2>Family Contact Information</h2>
-      <LabeledInput
-        label="Contact phone number"
-        patternConfig={Patterns.usPhoneNumber}
-        name="contactPhoneNumber"
-      />
-      <LabeledInput
-        label="Contact email address"
-        required={true}
-        name="contactEmail"
-      />
+      <Grid container spacing={2}>
+        <LabeledInput
+          label="Contact phone number"
+          patternConfig={Patterns.usPhoneNumber}
+          name="contactPhoneNumber"
+        />
+        <LabeledInput
+          label="Contact email address"
+          required={true}
+          name="contactEmail"
+        />
+      </Grid>
       {navButtons}
     </form>
   )

--- a/src/components/TaxPayer/ContactInfo.tsx
+++ b/src/components/TaxPayer/ContactInfo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { LabeledInput } from 'ustaxes/components/input'

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, PropsWithChildren, ReactElement } from 'react'
+import { Fragment, PropsWithChildren, ReactElement } from 'react'
 import {
   IconButton,
   List,

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -1,4 +1,4 @@
-import { Fragment, PropsWithChildren, ReactElement } from 'react'
+import { PropsWithChildren, ReactElement } from 'react'
 import {
   IconButton,
   List,
@@ -20,7 +20,7 @@ import { If } from 'react-if'
 export const PersonFields = ({
   children
 }: PropsWithChildren<Record<never, never>>): ReactElement => (
-  <Fragment>
+  <>
     <LabeledInput
       label="First Name and Initial"
       name="firstName"
@@ -33,7 +33,7 @@ export const PersonFields = ({
     />
     <LabeledInput label="SSN / TIN" name="ssid" patternConfig={Patterns.ssn} />
     {children}
-  </Fragment>
+  </>
 )
 
 interface PersonListItemProps {

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -19,7 +19,7 @@ import { If } from 'react-if'
 
 export const PersonFields = ({
   children
-}: PropsWithChildren<{}>): ReactElement => (
+}: PropsWithChildren<Record<never, never>>): ReactElement => (
   <Fragment>
     <LabeledInput
       label="First Name and Initial"
@@ -78,7 +78,9 @@ interface ListDependentsProps {
 }
 
 export function ListDependents({
-  onEdit,
+  onEdit = () => {
+    /* default do nothing */
+  },
   editing
 }: ListDependentsProps): ReactElement {
   const dependents = useSelector(
@@ -97,7 +99,7 @@ export function ListDependents({
           remove={() => drop(i)}
           person={p}
           editing={editing === i}
-          onEdit={() => (onEdit ?? (() => {}))(i)}
+          onEdit={() => onEdit(i)}
         />
       ))}
     </List>

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -30,6 +30,7 @@ import {
 import { PersonFields } from './PersonFields'
 import { FormListContainer } from 'ustaxes/components/FormContainer'
 import { usePager } from 'ustaxes/components/pager'
+import { Grid } from '@material-ui/core'
 import { Person } from '@material-ui/icons'
 
 interface UserPersonForm {
@@ -130,26 +131,28 @@ export const AddDependentForm = (): ReactElement => {
       icon={() => <Person />}
       removeItem={(i) => dispatch(removeDependent(i))}
     >
-      <PersonFields />
-      <LabeledInput
-        label="Relationship to Taxpayer"
-        name="relationship"
-        patternConfig={Patterns.name}
-      />
-      <LabeledInput
-        label="Birth Year"
-        patternConfig={Patterns.year}
-        name="birthYear"
-      />
-      <LabeledInput
-        label="How many months did you live together this year?"
-        patternConfig={Patterns.numMonths}
-        name="numberOfMonths"
-      />
-      <LabeledCheckbox
-        label="Is this person a full-time student?"
-        name="isStudent"
-      />
+      <Grid container spacing={2}>
+        <PersonFields />
+        <LabeledInput
+          label="Relationship to Taxpayer"
+          name="relationship"
+          patternConfig={Patterns.name}
+        />
+        <LabeledInput
+          label="Birth Year"
+          patternConfig={Patterns.year}
+          name="birthYear"
+        />
+        <LabeledInput
+          label="How many months did you live together this year?"
+          patternConfig={Patterns.numMonths}
+          name="numberOfMonths"
+        />
+        <LabeledCheckbox
+          label="Is this person a full-time student?"
+          name="isStudent"
+        />
+      </Grid>
     </FormListContainer>
   )
 
@@ -197,12 +200,14 @@ export const SpouseInfo = (): ReactElement => {
       editing={editing ? 0 : undefined}
       removeItem={() => dispatch(removeSpouse)}
     >
-      <PersonFields>
-        <LabeledCheckbox
-          label="Check if your spouse is a dependent"
-          name="isTaxpayerDependent"
-        />
-      </PersonFields>
+      <Grid container spacing={2}>
+        <PersonFields>
+          <LabeledCheckbox
+            label="Check if your spouse is a dependent"
+            name="isTaxpayerDependent"
+          />
+        </PersonFields>
+      </Grid>
     </FormListContainer>
   )
 
@@ -233,26 +238,22 @@ const SpouseAndDependent = (): ReactElement => {
   const page = (
     <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
       <h2>Family Information</h2>
-
-      <strong>
-        <p>Spouse Information</p>
-      </strong>
+      <h3>Spouse Information</h3>
       <SpouseInfo />
 
-      <strong>
-        <p>Dependent Information</p>
-      </strong>
+      <h3>Dependent Information</h3>
       <AddDependentForm />
 
-      <GenericLabeledDropdown<FilingStatus>
-        label=""
-        strongLabel="Filing Status"
-        dropDownData={filingStatuses(taxPayer)}
-        valueMapping={(x, i) => x}
-        keyMapping={(x, i) => i}
-        textMapping={(status) => FilingStatusTexts[status]}
-        name="filingStatus"
-      />
+      <Grid container spacing={2}>
+        <GenericLabeledDropdown<FilingStatus>
+          label="Filing Status"
+          dropDownData={filingStatuses(taxPayer)}
+          valueMapping={(x, i) => x}
+          keyMapping={(x, i) => i}
+          textMapping={(status) => FilingStatusTexts[status]}
+          name="filingStatus"
+        />
+      </Grid>
       {navButtons}
     </form>
   )

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 
 import { useForm, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -248,7 +248,7 @@ const SpouseAndDependent = (): ReactElement => {
         <GenericLabeledDropdown<FilingStatus>
           label="Filing Status"
           dropDownData={filingStatuses(taxPayer)}
-          valueMapping={(x, i) => x}
+          valueMapping={(x) => x}
           keyMapping={(x, i) => i}
           textMapping={(status) => FilingStatusTexts[status]}
           name="filingStatus"

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import {

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   savePrimaryPersonInfo,
@@ -53,14 +53,11 @@ const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
   role: PersonRole.PRIMARY
 })
 
-const asTaxPayerUserForm = (person: PrimaryPerson): TaxPayerUserForm => {
-  const { role, ...rest } = person
-  return {
-    ...rest,
-    isForeignCountry: person.address.foreignCountry !== undefined,
-    role: PersonRole.PRIMARY
-  }
-}
+const asTaxPayerUserForm = (person: PrimaryPerson): TaxPayerUserForm => ({
+  ...person,
+  isForeignCountry: person.address.foreignCountry !== undefined,
+  role: PersonRole.PRIMARY
+})
 
 export default function PrimaryTaxpayer(): ReactElement {
   // const variable dispatch to allow use inside function

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -18,6 +18,7 @@ import { PersonFields } from './PersonFields'
 import { usePager } from 'ustaxes/components/pager'
 import { LabeledCheckbox, USStateDropDown } from 'ustaxes/components/input'
 import AddressFields from './Address'
+import { Grid } from '@material-ui/core'
 
 interface TaxPayerUserForm {
   firstName: string
@@ -101,13 +102,15 @@ export default function PrimaryTaxpayer(): ReactElement {
   const page = (
     <form onSubmit={handleSubmit(onSubmit(onAdvance))}>
       <h2>Primary Taxpayer Information</h2>
-      <PersonFields />
-      <LabeledCheckbox
-        label="Check if you are a dependent"
-        name="isTaxpayerDependent"
-      />
-      <AddressFields checkboxText="Do you have a foreign address?" />
-      <USStateDropDown label="Residency State" name="stateResidency" />
+      <Grid container spacing={2}>
+        <PersonFields />
+        <LabeledCheckbox
+          label="Check if you are a dependent"
+          name="isTaxpayerDependent"
+        />
+        <AddressFields checkboxText="Do you have a foreign address?" />
+        <USStateDropDown label="Residency State" name="stateResidency" />
+      </Grid>
       {navButtons}
     </form>
   )

--- a/src/components/createPDF.tsx
+++ b/src/components/createPDF.tsx
@@ -35,7 +35,7 @@ export default function CreatePDF(): ReactElement {
 
   const { navButtons } = usePager()
 
-  const federalReturn = async (e: FormEvent<any>): Promise<void> => {
+  const federalReturn = async (e: FormEvent<Element>): Promise<void> => {
     e.preventDefault()
     return await createPDFPopup(federalFileName).catch((errors: string[]) => {
       if (errors.length !== undefined && errors.length > 0) {

--- a/src/components/createPDF.tsx
+++ b/src/components/createPDF.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, ReactElement, useState } from 'react'
+import { FormEvent, ReactElement, useState } from 'react'
 import { usePager } from './pager'
 import Alert from '@material-ui/lab/Alert'
 import { makeStyles } from '@material-ui/core/styles'

--- a/src/components/debug.tsx
+++ b/src/components/debug.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { IconButton, makeStyles, Theme } from '@material-ui/core'
+import { IconButton, makeStyles } from '@material-ui/core'
 import { Star } from '@material-ui/icons'
 import fc from 'fast-check'
 import { useDispatch } from 'react-redux'
@@ -8,7 +8,7 @@ import { TaxesState } from 'ustaxes/redux/data'
 import { taxesState } from 'ustaxes/tests/arbitraries'
 import * as prand from 'pure-rand'
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     position: 'absolute',
     top: '0px',

--- a/src/components/debug.tsx
+++ b/src/components/debug.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { IconButton, makeStyles } from '@material-ui/core'
 import { Star } from '@material-ui/icons'
 import fc from 'fast-check'

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import SchoolIcon from '@material-ui/icons/School'
 import { useDispatch, useSelector } from 'react-redux'

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -8,6 +8,7 @@ import { Currency, LabeledInput } from 'ustaxes/components/input'
 import { TaxesState, F1098e } from 'ustaxes/redux/data'
 import { Patterns } from 'ustaxes/components/Patterns'
 import { FormListContainer } from 'ustaxes/components/FormContainer'
+import { Grid } from '@material-ui/core'
 
 const showInterest = (a: F1098e): ReactElement => {
   return <Currency value={a.interest} />
@@ -86,17 +87,21 @@ export default function F1098eInfo(): ReactElement {
       secondary={(f) => showInterest(f)}
       icon={(f) => <SchoolIcon />}
     >
-      <strong>Input data from 1098-E</strong>
-      <LabeledInput
-        label="Enter name of Lender"
-        patternConfig={Patterns.name}
-        name="lender"
-      />
-      <LabeledInput
-        label="Student Interest Paid"
-        patternConfig={Patterns.currency}
-        name="interest"
-      />
+      <p>
+        <strong>Input data from 1098-E</strong>
+      </p>
+      <Grid container spacing={2}>
+        <LabeledInput
+          label="Enter name of Lender"
+          patternConfig={Patterns.name}
+          name="lender"
+        />
+        <LabeledInput
+          label="Student Interest Paid"
+          patternConfig={Patterns.currency}
+          name="interest"
+        />
+      </Grid>
     </FormListContainer>
   )
 

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -85,7 +85,7 @@ export default function F1098eInfo(): ReactElement {
       editItem={setEditing}
       primary={(f) => f.lender}
       secondary={(f) => showInterest(f)}
-      icon={(f) => <SchoolIcon />}
+      icon={() => <SchoolIcon />}
     >
       <p>
         <strong>Input data from 1098-E</strong>

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useState } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
-import { Icon } from '@material-ui/core'
+import { Icon, Grid } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import { add1099, edit1099, remove1099 } from 'ustaxes/redux/actions'
 import { usePager } from 'ustaxes/components/pager'
@@ -224,42 +224,56 @@ export default function F1099Info(): ReactElement {
     .map((p) => p as Person)
 
   const intFields = (
-    <LabeledInput
-      label="Box 1 - Interest Income"
-      patternConfig={Patterns.currency}
-      name="interest"
-    />
+    <Grid container spacing={2}>
+      <LabeledInput
+        label={
+          <>
+            <strong>Box 1</strong> - Interest Income
+          </>
+        }
+        patternConfig={Patterns.currency}
+        name="interest"
+      />
+    </Grid>
   )
 
   const bFields = (
-    <div>
-      <h4>Long Term Covered Transactions</h4>
-      <LabeledInput
-        label="Proceeds"
-        patternConfig={Patterns.currency}
-        name="longTermProceeds"
-      />
-      <LabeledInput
-        label="Cost basis"
-        patternConfig={Patterns.currency}
-        name="longTermCostBasis"
-      />
-      <h4>Short Term Covered Transactions</h4>
-      <LabeledInput
-        label="Proceeds"
-        patternConfig={Patterns.currency}
-        name="shortTermProceeds"
-      />
-      <LabeledInput
-        label="Cost basis"
-        patternConfig={Patterns.currency}
-        name="shortTermCostBasis"
-      />
-    </div>
+    <>
+      <h3>Long Term Covered Transactions</h3>
+      <Grid container spacing={2}>
+        <LabeledInput
+          label="Proceeds"
+          patternConfig={Patterns.currency}
+          name="longTermProceeds"
+          sizes={{ xs: 6 }}
+        />
+        <LabeledInput
+          label="Cost basis"
+          patternConfig={Patterns.currency}
+          name="longTermCostBasis"
+          sizes={{ xs: 6 }}
+        />
+      </Grid>
+      <h3>Short Term Covered Transactions</h3>
+      <Grid container spacing={2}>
+        <LabeledInput
+          label="Proceeds"
+          patternConfig={Patterns.currency}
+          name="shortTermProceeds"
+          sizes={{ xs: 6 }}
+        />
+        <LabeledInput
+          label="Cost basis"
+          patternConfig={Patterns.currency}
+          name="shortTermCostBasis"
+          sizes={{ xs: 6 }}
+        />
+      </Grid>
+    </>
   )
 
   const divFields = (
-    <div>
+    <Grid container spacing={2}>
       <LabeledInput
         label="Total Dividends"
         patternConfig={Patterns.currency}
@@ -270,36 +284,47 @@ export default function F1099Info(): ReactElement {
         patternConfig={Patterns.currency}
         name="qualifiedDividends"
       />
-    </div>
+    </Grid>
   )
 
   const rFields = (
-    <div>
+    <Grid container spacing={2}>
       <LabeledInput
-        label="Box 1 - Gross Distribution"
+        label={
+          <>
+            <strong>Box 1</strong> - Gross Distribution
+          </>
+        }
         patternConfig={Patterns.currency}
         name="grossDistribution"
       />
       <LabeledInput
-        label="Box 2a - Taxable Amount"
+        label={
+          <>
+            <strong>Box 2a</strong> - Taxable Amount
+          </>
+        }
         patternConfig={Patterns.currency}
         name="taxableAmount"
       />
       <LabeledInput
-        label="Box 4 - Federal Income Tax Withheld"
+        label={
+          <>
+            <strong>Box 4</strong> - Federal Income Tax Withheld
+          </>
+        }
         patternConfig={Patterns.currency}
         name="federalIncomeTaxWithheld"
       />
       <GenericLabeledDropdown<PlanType1099>
-        label=""
-        strongLabel="Type of 1099-R"
+        label="Type of 1099-R"
         dropDownData={Object.values(PlanType1099)}
         valueMapping={(x, i) => x}
         keyMapping={(x, i) => i}
         textMapping={(status) => PlanType1099Texts[status]}
         name="RPlanType"
       />
-    </div>
+    </Grid>
   )
 
   const specificFields = {
@@ -326,39 +351,44 @@ export default function F1099Info(): ReactElement {
       editItem={setEditing}
       primary={(f) => f.payer}
       secondary={(f) => showIncome(f)}
-      icon={(f) => <Icon title={titles[f.type]}>{f.type}</Icon>}
+      icon={(f) => (
+        <Icon style={{ lineHeight: 1 }} title={titles[f.type]}>
+          {f.type}
+        </Icon>
+      )}
     >
-      <strong>Input data from 1099</strong>
+      <p>Input data from 1099</p>
+      <Grid container spacing={2}>
+        <GenericLabeledDropdown
+          dropDownData={Object.values(Income1099Type)}
+          label="Form Type"
+          valueMapping={(v: Income1099Type) => v}
+          name="formType"
+          keyMapping={(_, i: number) => i}
+          textMapping={(name: string) => `1099-${name}`}
+        />
 
-      <GenericLabeledDropdown
-        dropDownData={Object.values(Income1099Type)}
-        label="Form Type"
-        valueMapping={(v: Income1099Type) => v}
-        name="formType"
-        keyMapping={(_, i: number) => i}
-        textMapping={(name: string) => `1099-${name}`}
-      />
-
-      <LabeledInput
-        label="Enter name of bank, broker firm, or other payer"
-        patternConfig={Patterns.name}
-        name="payer"
-      />
-
+        <LabeledInput
+          label="Enter name of bank, broker firm, or other payer"
+          patternConfig={Patterns.name}
+          name="payer"
+        />
+      </Grid>
       {selectedType !== undefined ? specificFields[selectedType] : undefined}
-
-      <GenericLabeledDropdown
-        dropDownData={people}
-        label="Recipient"
-        valueMapping={(p: Person, i: number) =>
-          [PersonRole.PRIMARY, PersonRole.SPOUSE][i]
-        }
-        name="personRole"
-        keyMapping={(p: Person, i: number) => i}
-        textMapping={(p: Person) =>
-          `${p.firstName} ${p.lastName} (${formatSSID(p.ssid)})`
-        }
-      />
+      <Grid container spacing={2}>
+        <GenericLabeledDropdown
+          dropDownData={people}
+          label="Recipient"
+          valueMapping={(p: Person, i: number) =>
+            [PersonRole.PRIMARY, PersonRole.SPOUSE][i]
+          }
+          name="personRole"
+          keyMapping={(p: Person, i: number) => i}
+          textMapping={(p: Person) =>
+            `${p.firstName} ${p.lastName} (${formatSSID(p.ssid)})`
+          }
+        />
+      </Grid>
     </FormListContainer>
   )
 

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { Icon, Grid } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -319,8 +319,8 @@ export default function F1099Info(): ReactElement {
       <GenericLabeledDropdown<PlanType1099>
         label="Type of 1099-R"
         dropDownData={Object.values(PlanType1099)}
-        valueMapping={(x, i) => x}
-        keyMapping={(x, i) => i}
+        valueMapping={(x) => x}
+        keyMapping={(_, i) => i}
         textMapping={(status) => PlanType1099Texts[status]}
         name="RPlanType"
       />

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { Message, useForm, useWatch, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -239,66 +239,71 @@ export default function RealEstate(): ReactElement {
       removeItem={(i) => deleteProperty(i)}
       onCancel={clear}
     >
-      <h4>Property location</h4>
-      <AddressFields
-        checkboxText="Does the property have a foreign address"
-        allowForeignCountry={false}
-      />
-      <GenericLabeledDropdown
-        dropDownData={enumKeys(PropertyType)}
-        label="Property type"
-        textMapping={(t) => displayPropertyType(PropertyType[t])}
-        keyMapping={(_, n) => n}
-        name="propertyType"
-        valueMapping={(n) => n}
-      />
-      <If
-        condition={[propertyType, defaultValues?.propertyType].includes(
-          'other'
-        )}
-      >
-        <LabeledInput
-          name="otherPropertyType"
-          label="Short property type description"
-          required={true}
+      <h3>Property Location</h3>
+      <Grid container spacing={2}>
+        <AddressFields
+          checkboxText="Does the property have a foreign address"
+          allowForeignCountry={false}
         />
-      </If>
-      <h4>Use</h4>
-      <LabeledInput
-        name="rentalDays"
-        rules={{ validate: (n: String) => validateRental(Number(n)) }}
-        label="Number of days in the year used for rental"
-        patternConfig={Patterns.numDays}
-      />
-      <LabeledInput
-        name="personalUseDays"
-        rules={{ validate: (n: String) => validatePersonal(Number(n)) }}
-        label="Number of days in the year for personal use"
-        patternConfig={Patterns.numDays}
-      />
-      <LabeledCheckbox
-        name="qualifiedJointVenture"
-        label="Is this a qualified joint venture"
-      />
-      <h4>Property Financials</h4>
-      <h5>Income</h5>
-      <LabeledInput
-        name="rentReceived"
-        label="Rent received"
-        patternConfig={Patterns.currency}
-      />
-      <h5>Expenses</h5>
-      <Grid container spacing={3} direction="row" justify="flex-start">
+        <GenericLabeledDropdown
+          dropDownData={enumKeys(PropertyType)}
+          label="Property type"
+          textMapping={(t) => displayPropertyType(PropertyType[t])}
+          keyMapping={(_, n) => n}
+          name="propertyType"
+          valueMapping={(n) => n}
+        />
+        <If
+          condition={[propertyType, defaultValues?.propertyType].includes(
+            'other'
+          )}
+        >
+          <LabeledInput
+            name="otherPropertyType"
+            label="Short property type description"
+            required={true}
+          />
+        </If>
+      </Grid>
+      <h3>Use</h3>
+      <Grid container spacing={2}>
+        <LabeledInput
+          name="rentalDays"
+          rules={{ validate: (n: String) => validateRental(Number(n)) }}
+          label="Number of days in the year used for rental"
+          patternConfig={Patterns.numDays}
+        />
+        <LabeledInput
+          name="personalUseDays"
+          rules={{ validate: (n: String) => validatePersonal(Number(n)) }}
+          label="Number of days in the year for personal use"
+          patternConfig={Patterns.numDays}
+        />
+        <LabeledCheckbox
+          name="qualifiedJointVenture"
+          label="Is this a qualified joint venture"
+        />
+      </Grid>
+      <h3>Property Financials</h3>
+      <h4>Income</h4>
+      <Grid container spacing={2}>
+        <LabeledInput
+          name="rentReceived"
+          label="Rent received"
+          patternConfig={Patterns.currency}
+        />
+      </Grid>
+      <h4>Expenses</h4>
+      <Grid container spacing={2}>
         {
           // Layout expense fields in two columns
           segments(2, [...expenseFields, otherExpenseDescription]).map(
-            (segment, i) => (
-              <Grid item key={i} lg={6}>
-                {segment.map((item, k) => (
-                  <Fragment key={`${i}-${k}`}>{item}</Fragment>
-                ))}
-              </Grid>
-            )
+            (segment, i) =>
+              segment.map((item, k) => (
+                <Grid item key={`${i}-${k}`} xs={12} sm={6}>
+                  {item}
+                </Grid>
+              ))
           )
         }
       </Grid>

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -269,13 +269,13 @@ export default function RealEstate(): ReactElement {
       <Grid container spacing={2}>
         <LabeledInput
           name="rentalDays"
-          rules={{ validate: (n: String) => validateRental(Number(n)) }}
+          rules={{ validate: (n: string) => validateRental(Number(n)) }}
           label="Number of days in the year used for rental"
           patternConfig={Patterns.numDays}
         />
         <LabeledInput
           name="personalUseDays"
-          rules={{ validate: (n: String) => validatePersonal(Number(n)) }}
+          rules={{ validate: (n: string) => validatePersonal(Number(n)) }}
           label="Number of days in the year for personal use"
           patternConfig={Patterns.numDays}
         />

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { Message, useForm, useWatch, FormProvider } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import {

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement, ReactNode, useState } from 'react'
+import { ReactElement, ReactNode, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { FormProvider, useForm } from 'react-hook-form'
 import { usePager } from 'ustaxes/components/pager'
@@ -245,7 +245,7 @@ export default function W2JobInfo(): ReactElement {
   })()
 
   const form: ReactElement = (
-    <Fragment>
+    <>
       {primaryW2sBlock}
       {spouseW2sBlock}
       <If condition={editing === undefined}>
@@ -254,7 +254,7 @@ export default function W2JobInfo(): ReactElement {
           showW2s([])
         }
       </If>
-    </Fragment>
+    </>
   )
 
   return (

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode, useState } from 'react'
+import { Fragment, ReactElement, ReactNode, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { FormProvider, useForm } from 'react-hook-form'
 import { usePager } from 'ustaxes/components/pager'

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -115,12 +115,12 @@ export default function W2JobInfo(): ReactElement {
 
   const showW2s = (
     _w2s: Array<[IncomeW2, number]>,
-    omitAdd: boolean = false
+    omitAdd = false
   ): ReactElement => (
     <FormListContainer<[IncomeW2, number]>
       items={_w2s}
       onDone={(onSuccess) => handleSubmit(onAddW2(onSuccess))}
-      editing={_w2s.findIndex(([_, idx]) => idx === editing)}
+      editing={_w2s.findIndex(([, idx]) => idx === editing)}
       disableEditing={editing !== undefined}
       editItem={(idx) => setEditing(_w2s[idx][1])}
       removeItem={(i) => dispatch(removeW2(i))}

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -20,7 +20,7 @@ import {
 } from 'ustaxes/components/input'
 import { Patterns } from 'ustaxes/components/Patterns'
 import { FormListContainer } from 'ustaxes/components/FormContainer'
-import { Box } from '@material-ui/core'
+import { Grid } from '@material-ui/core'
 import { Work } from '@material-ui/icons'
 import { addW2, editW2, removeW2 } from 'ustaxes/redux/actions'
 import { If } from 'react-if'
@@ -136,59 +136,74 @@ export default function W2JobInfo(): ReactElement {
       onCancel={clear}
       max={omitAdd ? 0 : undefined}
     >
-      <strong>Input data from W-2</strong>
-      <LabeledInput
-        label="Employer name"
-        patternConfig={Patterns.name}
-        name="employer.employerName"
-      />
-      <LabeledInput
-        label="Occupation"
-        patternConfig={Patterns.name}
-        name="occupation"
-      />
-
-      <LabeledInput
-        strongLabel="Box 1 - "
-        label="Wages, tips, other compensation"
-        patternConfig={Patterns.currency}
-        name="income"
-      />
-
-      <LabeledInput
-        strongLabel="Box 2 - "
-        label="Federal income tax withheld"
-        name="fedWithholding"
-        patternConfig={Patterns.currency}
-      />
-
-      <LabeledInput
-        strongLabel="Box 4 - "
-        label="Social security tax withheld"
-        name="ssWithholding"
-        patternConfig={Patterns.currency}
-      />
-
-      <LabeledInput
-        strongLabel="Box 6 - "
-        label="Medicare tax withheld"
-        name="medicareWithholding"
-        patternConfig={Patterns.currency}
-      />
-
-      <GenericLabeledDropdown
-        dropDownData={people}
-        label="Employee"
-        required={true}
-        valueMapping={(p: Person, i: number) =>
-          [PersonRole.PRIMARY, PersonRole.SPOUSE][i]
-        }
-        name="personRole"
-        keyMapping={(p: Person, i: number) => i}
-        textMapping={(p) =>
-          `${p.firstName} ${p.lastName} (${formatSSID(p.ssid)})`
-        }
-      />
+      <p>Input data from W-2</p>
+      <Grid container spacing={2}>
+        <LabeledInput
+          label="Employer name"
+          patternConfig={Patterns.name}
+          name="employer.employerName"
+          sizes={{ xs: 12 }}
+        />
+        <LabeledInput
+          label="Occupation"
+          patternConfig={Patterns.name}
+          name="occupation"
+          sizes={{ xs: 12 }}
+        />
+        <LabeledInput
+          name="income"
+          label={
+            <>
+              <strong>Box 1</strong> - Wages, tips, other compensation
+            </>
+          }
+          patternConfig={Patterns.currency}
+          sizes={{ xs: 12, lg: 6 }}
+        />
+        <LabeledInput
+          name="fedWithholding"
+          label={
+            <>
+              <strong>Box 2</strong> - Federal income tax withheld
+            </>
+          }
+          patternConfig={Patterns.currency}
+          sizes={{ xs: 12, lg: 6 }}
+        />
+        <LabeledInput
+          name="ssWithholding"
+          label={
+            <>
+              <strong>Box 4</strong> - Social security tax withheld
+            </>
+          }
+          patternConfig={Patterns.currency}
+          sizes={{ xs: 12, lg: 6 }}
+        />
+        <LabeledInput
+          name="medicareWithholding"
+          label={
+            <>
+              <strong>Box 6</strong> - Medicare tax withheld
+            </>
+          }
+          patternConfig={Patterns.currency}
+          sizes={{ xs: 12, lg: 6 }}
+        />
+        <GenericLabeledDropdown
+          dropDownData={people}
+          label="Employee"
+          required={true}
+          valueMapping={(p: Person, i: number) =>
+            [PersonRole.PRIMARY, PersonRole.SPOUSE][i]
+          }
+          name="personRole"
+          keyMapping={(p: Person, i: number) => i}
+          textMapping={(p) =>
+            `${p.firstName} ${p.lastName} (${formatSSID(p.ssid)})`
+          }
+        />
+      </Grid>
     </FormListContainer>
   )
 
@@ -196,13 +211,13 @@ export default function W2JobInfo(): ReactElement {
     if (primary !== undefined && primaryW2s.length > 0) {
       if (spouse !== undefined) {
         return (
-          <Box className="inner">
+          <>
             <h3>
               {primary.firstName ?? 'Primary'} {primary.lastName ?? 'Taxpayer'}
               &apos;s W2s
             </h3>
             {showW2s(primaryW2s, true)}
-          </Box>
+          </>
         )
       } else {
         return showW2s(primaryW2s, true)
@@ -214,7 +229,7 @@ export default function W2JobInfo(): ReactElement {
     if (spouse !== undefined && spouseW2s.length > 0) {
       const name = `${spouse.firstName} ${spouse.lastName}`
       return (
-        <Box className="inner">
+        <>
           <h3>{name}&apos;s W2s</h3>
           {showW2s(spouseW2s, true)}
           <If condition={filingStatus === FilingStatus.MFS}>
@@ -224,7 +239,7 @@ export default function W2JobInfo(): ReactElement {
               &apos;s W2s will not be added to the return.
             </Alert>
           </If>
-        </Box>
+        </>
       )
     }
   })()
@@ -236,7 +251,7 @@ export default function W2JobInfo(): ReactElement {
       <If condition={editing === undefined}>
         {
           // just for Add button:
-          <Box className="inner">{showW2s([])}</Box>
+          showW2s([])
         }
       </If>
     </Fragment>

--- a/src/components/input/Currency.tsx
+++ b/src/components/input/Currency.tsx
@@ -3,7 +3,7 @@ import { CurrencyProps } from './types'
 import NumberFormat from 'react-number-format'
 import { makeStyles } from '@material-ui/core/styles'
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   positive: {
     color: 'green'
   },

--- a/src/components/input/Currency.tsx
+++ b/src/components/input/Currency.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { CurrencyProps } from './types'
 import NumberFormat from 'react-number-format'
 import { makeStyles } from '@material-ui/core/styles'

--- a/src/components/input/LabeledCheckbox.tsx
+++ b/src/components/input/LabeledCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import {
   Checkbox,
   FormControl,

--- a/src/components/input/LabeledCheckbox.tsx
+++ b/src/components/input/LabeledCheckbox.tsx
@@ -3,23 +3,29 @@ import {
   Checkbox,
   FormControl,
   FormControlLabel,
-  FormGroup
+  FormGroup,
+  Grid
 } from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import { LabeledCheckboxProps } from './types'
-import useStyles from './styles'
+import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
 
 export function LabeledCheckbox(props: LabeledCheckboxProps): ReactElement {
-  const { label, name } = props
+  const { label, name, useGrid = true, sizes = { xs: 12 } } = props
   const { control } = useFormContext()
 
-  const classes = useStyles()
-
   return (
-    <Controller
-      name={name}
-      render={({ field: { value, onChange } }) => (
-        <div className={classes.root}>
+    <ConditionallyWrap
+      condition={useGrid}
+      wrapper={(children) => (
+        <Grid item {...sizes}>
+          {children}
+        </Grid>
+      )}
+    >
+      <Controller
+        name={name}
+        render={({ field: { value, onChange } }) => (
           <FormControl component="fieldset">
             <FormGroup>
               <FormControlLabel
@@ -36,10 +42,10 @@ export function LabeledCheckbox(props: LabeledCheckboxProps): ReactElement {
               />
             </FormGroup>
           </FormControl>
-        </div>
-      )}
-      control={control}
-    />
+        )}
+        control={control}
+      />
+    </ConditionallyWrap>
   )
 }
 

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement } from 'react'
-import {
-  createStyles,
-  makeStyles,
-  Grid,
-  TextField,
-  Theme
-} from '@material-ui/core'
+import { createStyles, makeStyles, Grid, TextField } from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import locationPostalCodes from 'ustaxes/data/locationPostalCodes'
 import { BaseDropdownProps, LabeledDropdownProps } from './types'
@@ -14,7 +8,7 @@ import countries from 'ustaxes/data/countries'
 import { State } from 'ustaxes/redux/data'
 import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
     root: {
       '& .MuiFormLabel-root': {
@@ -115,9 +109,9 @@ export const USStateDropDown = (props: BaseDropdownProps): ReactElement => (
   <GenericLabeledDropdown<[string, State]>
     {...props}
     dropDownData={locationPostalCodes}
-    valueMapping={([, code], n) => code}
-    keyMapping={([, code], n) => code}
-    textMapping={([name, code], n) => `${code} - ${name}`}
+    valueMapping={([, code]) => code}
+    keyMapping={([, code]) => code}
+    textMapping={([name, code]) => `${code} - ${name}`}
   />
 )
 
@@ -125,9 +119,9 @@ export const CountryDropDown = (props: BaseDropdownProps): ReactElement => (
   <GenericLabeledDropdown<string>
     {...props}
     dropDownData={countries}
-    valueMapping={(name, _) => name}
+    valueMapping={(name) => name}
     keyMapping={(_, idx) => idx}
-    textMapping={(name, _) => name}
+    textMapping={(name) => name}
   />
 )
 

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { createStyles, makeStyles, Grid, TextField } from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import locationPostalCodes from 'ustaxes/data/locationPostalCodes'

--- a/src/components/input/LabeledDropdown.tsx
+++ b/src/components/input/LabeledDropdown.tsx
@@ -1,72 +1,97 @@
 import React, { ReactElement } from 'react'
-import { Box, TextField } from '@material-ui/core'
+import {
+  createStyles,
+  makeStyles,
+  Grid,
+  TextField,
+  Theme
+} from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import locationPostalCodes from 'ustaxes/data/locationPostalCodes'
 import { BaseDropdownProps, LabeledDropdownProps } from './types'
 import _ from 'lodash'
 import countries from 'ustaxes/data/countries'
 import { State } from 'ustaxes/redux/data'
+import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '& .MuiFormLabel-root': {
+        color: 'rgba(0, 0, 0, 0.54)'
+      }
+    }
+  })
+)
 
 export function GenericLabeledDropdown<A>(
   props: LabeledDropdownProps<A>
 ): ReactElement {
+  const classes = useStyles()
   const {
     control,
     formState: { errors }
   } = useFormContext()
   const {
-    strongLabel,
     label,
     dropDownData,
     valueMapping,
     keyMapping,
     textMapping,
     required = true,
-    name
+    name,
+    useGrid = true,
+    sizes = { xs: 12 }
   } = props
   const error = _.get(errors, name)
 
   return (
-    <div>
-      <Box display="flex" justifyContent="flex-start">
-        <p>
-          <strong>{strongLabel}</strong>
-          {label}
-        </p>
-      </Box>
-      <Box display="flex" justifyContent="flex-start">
-        <Controller
-          render={({ field: { value, onChange } }) => (
-            <TextField
-              select
-              fullWidth
-              variant="filled"
-              name={name}
-              helperText={error !== undefined ? 'Make a selection' : undefined}
-              error={error !== undefined}
-              SelectProps={{
-                native: true,
-                value,
-                onChange
-              }}
-            >
-              <option value={''} />
-              {dropDownData.map((dropDownItem: A, i: number) => (
-                <option
-                  value={valueMapping(dropDownItem, i)}
-                  key={keyMapping(dropDownItem, i)}
-                >
-                  {textMapping(dropDownItem, i)}
-                </option>
-              ))}
-            </TextField>
-          )}
-          name={name}
-          rules={{ required: required }}
-          control={control}
-        />
-      </Box>
-    </div>
+    <ConditionallyWrap
+      condition={useGrid}
+      wrapper={(children) => (
+        <Grid item {...sizes}>
+          {children}
+        </Grid>
+      )}
+    >
+      <Controller
+        render={({ field: { name, onChange, ref, value } }) => (
+          <TextField
+            inputRef={ref}
+            id={name}
+            name={name}
+            className={classes.root}
+            label={label}
+            select
+            fullWidth
+            variant="filled"
+            helperText={error !== undefined ? 'Make a selection' : undefined}
+            error={error !== undefined}
+            SelectProps={{
+              native: true,
+              value,
+              onChange
+            }}
+            InputLabelProps={{
+              shrink: true
+            }}
+          >
+            <option value={''} />
+            {dropDownData.map((dropDownItem: A, i: number) => (
+              <option
+                value={valueMapping(dropDownItem, i)}
+                key={keyMapping(dropDownItem, i)}
+              >
+                {textMapping(dropDownItem, i)}
+              </option>
+            ))}
+          </TextField>
+        )}
+        name={name}
+        rules={{ required: required }}
+        control={control}
+      />
+    </ConditionallyWrap>
   )
 }
 

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import {
   createStyles,
   makeStyles,

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -4,8 +4,7 @@ import {
   makeStyles,
   InputAdornment,
   Grid,
-  TextField,
-  Theme
+  TextField
 } from '@material-ui/core'
 import { LabeledInputProps } from './types'
 import NumberFormat from 'react-number-format'
@@ -14,7 +13,7 @@ import { isNumeric, Patterns } from 'ustaxes/components/Patterns'
 import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
 import _ from 'lodash'
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles(() =>
   createStyles({
     root: {
       '& .MuiFormLabel-root': {

--- a/src/components/input/LabeledInput.tsx
+++ b/src/components/input/LabeledInput.tsx
@@ -1,21 +1,38 @@
 import React, { ReactElement } from 'react'
-import { TextField } from '@material-ui/core'
+import {
+  createStyles,
+  makeStyles,
+  InputAdornment,
+  Grid,
+  TextField,
+  Theme
+} from '@material-ui/core'
 import { LabeledInputProps } from './types'
 import NumberFormat from 'react-number-format'
 import { Controller, useFormContext } from 'react-hook-form'
 import { isNumeric, Patterns } from 'ustaxes/components/Patterns'
+import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
 import _ from 'lodash'
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '& .MuiFormLabel-root': {
+        color: 'rgba(0, 0, 0, 0.54)'
+      }
+    }
+  })
+)
+
 export function LabeledInput(props: LabeledInputProps): ReactElement {
-  const {
-    strongLabel,
-    label,
-    patternConfig: patternConfigDefined,
-    name,
-    rules = {}
-  } = props
+  const { label, patternConfig: patternConfigDefined, name, rules = {} } = props
   const { required = patternConfigDefined !== undefined } = props
-  const { patternConfig = Patterns.plain } = props
+  const {
+    patternConfig = Patterns.plain,
+    useGrid = true,
+    sizes = { xs: 12 }
+  } = props
+  const classes = useStyles()
 
   const {
     control,
@@ -42,25 +59,40 @@ export function LabeledInput(props: LabeledInputProps): ReactElement {
     if (isNumeric(patternConfig)) {
       return (
         <Controller
-          render={({ field: { onChange, value } }) => (
+          name={name}
+          control={control}
+          render={({ field: { name, onChange, ref, value } }) => (
             <NumberFormat
+              customInput={TextField}
+              inputRef={ref}
+              id={name}
               name={name}
+              className={classes.root}
+              label={label}
               mask={patternConfig.mask}
               thousandSeparator={patternConfig.thousandSeparator}
-              prefix={patternConfig.prefix}
+              // prefix={patternConfig.prefix}
               allowEmptyFormatting={true}
               format={patternConfig.format}
-              customInput={TextField}
               isNumericString={false}
               onValueChange={(v) => onChange(v.value)}
               value={value ?? ''}
               error={error !== undefined}
+              fullWidth
               helperText={errorMessage}
               variant="filled"
+              InputLabelProps={{
+                shrink: true
+              }}
+              InputProps={{
+                startAdornment: patternConfig.prefix ? (
+                  <InputAdornment position="start">
+                    {patternConfig.prefix}
+                  </InputAdornment>
+                ) : undefined
+              }}
             />
           )}
-          name={name}
-          control={control}
           rules={{
             ...rules,
             min: patternConfig.min,
@@ -81,7 +113,7 @@ export function LabeledInput(props: LabeledInputProps): ReactElement {
       <Controller
         control={control}
         name={name}
-        render={({ field: { onChange, value } }) => (
+        render={({ field: { onChange, value, name } }) => (
           <TextField
             {...register(name, {
               ...rules,
@@ -93,12 +125,19 @@ export function LabeledInput(props: LabeledInputProps): ReactElement {
                   (required ? 'Input is required' : '')
               }
             })}
+            id={name}
+            name={name}
+            className={classes.root}
+            label={label}
             value={value ?? ''}
             onChange={onChange}
-            fullWidth={patternConfig?.format === undefined}
+            fullWidth
             helperText={error?.message}
             error={error !== undefined}
             variant="filled"
+            InputLabelProps={{
+              shrink: true
+            }}
           />
         )}
       />
@@ -106,13 +145,16 @@ export function LabeledInput(props: LabeledInputProps): ReactElement {
   })()
 
   return (
-    <div>
-      <p>
-        <strong>{strongLabel}</strong>
-        {label}
-      </p>
+    <ConditionallyWrap
+      condition={useGrid}
+      wrapper={(children) => (
+        <Grid item {...sizes}>
+          {children}
+        </Grid>
+      )}
+    >
       {input}
-    </div>
+    </ConditionallyWrap>
   )
 }
 

--- a/src/components/input/LabeledRadio.tsx
+++ b/src/components/input/LabeledRadio.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import {
   FormControl,
   FormControlLabel,

--- a/src/components/input/LabeledRadio.tsx
+++ b/src/components/input/LabeledRadio.tsx
@@ -2,40 +2,52 @@ import React, { ReactElement } from 'react'
 import {
   FormControl,
   FormControlLabel,
+  FormLabel,
+  Grid,
   Radio,
   RadioGroup
 } from '@material-ui/core'
 import { Controller, useFormContext } from 'react-hook-form'
 import { LabeledRadioProps } from './types'
 import useStyles from './styles'
+import ConditionallyWrap from 'ustaxes/components/ConditionallyWrap'
 
 export function LabeledRadio(props: LabeledRadioProps): ReactElement {
-  const { label, name, values } = props
+  const { label, name, values, useGrid = true, sizes = { xs: 12 } } = props
 
   const classes = useStyles()
   const { control } = useFormContext()
 
   return (
-    <Controller
-      name={name}
-      render={({ field: { value, onChange } }) => (
-        <div className={classes.root}>
-          <FormControl component="fieldset">
-            {label}
-            <RadioGroup name={name} value={value} onChange={onChange}>
-              {values.map(([rowLabel, rowValue], i) => (
-                <FormControlLabel
-                  key={i}
-                  value={rowValue}
-                  control={<Radio color="primary" />}
-                  label={rowLabel}
-                />
-              ))}
-            </RadioGroup>
-          </FormControl>
-        </div>
+    <ConditionallyWrap
+      condition={useGrid}
+      wrapper={(children) => (
+        <Grid item {...sizes}>
+          {children}
+        </Grid>
       )}
-      control={control}
-    />
+    >
+      <Controller
+        name={name}
+        render={({ field: { value, onChange } }) => (
+          <div className={classes.root}>
+            <FormControl component="fieldset">
+              <FormLabel>{label}</FormLabel>
+              <RadioGroup name={name} value={value} onChange={onChange}>
+                {values.map(([rowLabel, rowValue], i) => (
+                  <FormControlLabel
+                    key={i}
+                    value={rowValue}
+                    control={<Radio color="primary" />}
+                    label={rowLabel}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </div>
+        )}
+        control={control}
+      />
+    </ConditionallyWrap>
   )
 }

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -2,9 +2,9 @@ import { makeStyles } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    margin: theme.spacing(1, 3, 0, 0)
+    '& .MuiFormLabel-root': {
+      color: 'rgba(0, 0, 0, 0.54)'
+    }
   }
 }))
 

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core'
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     '& .MuiFormLabel-root': {
       color: 'rgba(0, 0, 0, 0.54)'

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -1,9 +1,9 @@
+import { ReactElement } from 'react'
 import { RegisterOptions } from 'react-hook-form'
 import { PatternConfig } from 'ustaxes/components/Patterns'
-
+import { GridSize } from '@material-ui/core/Grid'
 export interface BaseDropdownProps {
-  label: string
-  strongLabel?: string
+  label: string | ReactElement
   required?: boolean
   name: string
 }
@@ -14,7 +14,16 @@ export interface CurrencyProps {
   plain?: boolean
 }
 
+interface SizeList {
+  xs?: boolean | GridSize
+  sm?: boolean | GridSize
+  md?: boolean | GridSize
+  lg?: boolean | GridSize
+}
+
 export interface LabeledDropdownProps<A> extends BaseDropdownProps {
+  useGrid?: boolean
+  sizes?: SizeList
   dropDownData: A[]
   valueMapping: (a: A, n: number) => string
   keyMapping: (a: A, n: number) => string | number
@@ -22,9 +31,10 @@ export interface LabeledDropdownProps<A> extends BaseDropdownProps {
 }
 
 export interface LabeledInputProps {
-  strongLabel?: string
+  useGrid?: boolean
+  sizes?: SizeList
   patternConfig?: PatternConfig
-  label: string
+  label: string | ReactElement
   required?: boolean
   name: string
   defaultValue?: string
@@ -37,6 +47,8 @@ export interface LabeledInputProps {
 export interface LabeledFormProps {
   name: string
   label: string
+  useGrid?: boolean
+  sizes?: SizeList
 }
 
 export type LabeledCheckboxProps = LabeledFormProps

--- a/src/components/pager.tsx
+++ b/src/components/pager.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, PropsWithChildren } from 'react'
+import { createContext, ReactElement, useState, PropsWithChildren } from 'react'
 import { Box, Button } from '@material-ui/core'
 import { useContext } from 'react'
 import { Link, useHistory } from 'react-router-dom'
@@ -8,7 +8,7 @@ interface PagerProps {
   navButtons: ReactElement
 }
 
-export const PagerContext = React.createContext<PagerProps>({
+export const PagerContext = createContext<PagerProps>({
   onAdvance: () => {
     /* just a placeholder */
   },

--- a/src/components/pager.tsx
+++ b/src/components/pager.tsx
@@ -9,7 +9,9 @@ interface PagerProps {
 }
 
 export const PagerContext = React.createContext<PagerProps>({
-  onAdvance: () => {},
+  onAdvance: () => {
+    /* just a placeholder */
+  },
   navButtons: <></>
 })
 
@@ -61,7 +63,14 @@ export const PagerProvider = <A extends Page>({
 
   return (
     <PagerContext.Provider
-      value={{ onAdvance: onAdvance ?? (() => {}), navButtons }}
+      value={{
+        onAdvance:
+          onAdvance ??
+          (() => {
+            // end of pages
+          }),
+        navButtons
+      }}
     >
       {children}
     </PagerContext.Provider>

--- a/src/components/pager.tsx
+++ b/src/components/pager.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState, PropsWithChildren } from 'react'
 import { Box, Button } from '@material-ui/core'
 import { useContext } from 'react'
-import { Context } from 'react'
 import { Link, useHistory } from 'react-router-dom'
 
 interface PagerProps {
@@ -81,7 +80,7 @@ export const PagerButtons = ({
   const backButton = (() => {
     if (previousUrl !== undefined) {
       return (
-        <Box display="flex" justifyContent="flex-start" paddingRight={2}>
+        <Box display="flex" justifyContent="flex-start" marginRight={2}>
           <Button
             component={Link}
             to={previousUrl}
@@ -99,8 +98,8 @@ export const PagerButtons = ({
     <Box
       display="flex"
       justifyContent="flex-start"
-      paddingTop={2}
-      paddingBottom={1}
+      marginTop={2}
+      marginBottom={1}
     >
       {backButton}
       <Button type="submit" name="submit" variant="contained" color="primary">
@@ -127,8 +126,8 @@ export const StartButtons = ({
     <Box
       display="flex"
       justifyContent="space-evenly"
-      paddingTop={3}
-      paddingBottom={6}
+      marginTop={3}
+      marginBottom={6}
     >
       <Button
         component={Link}
@@ -158,8 +157,8 @@ export const SingleButtons = ({
     <Box
       display="flex"
       justifyContent="space-evenly"
-      paddingTop={3}
-      paddingBottom={6}
+      marginTop={3}
+      marginBottom={6}
     >
       <Button component={Link} to={url} variant="contained" color="primary">
         {text}

--- a/src/customTypes/persistStore.d.ts
+++ b/src/customTypes/persistStore.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Provides type override for persistStore so that
  * custom state and action types can be easily used.

--- a/src/data/federal.ts
+++ b/src/data/federal.ts
@@ -135,7 +135,7 @@ export const fica = {
 
   regularMedicareTaxRate: 1.45 / 100,
   additionalMedicareTaxRate: 0.9 / 100,
-  additionalMedicareTaxThreshold: (filingStatus: FilingStatus) => {
+  additionalMedicareTaxThreshold: (filingStatus: FilingStatus): number => {
     switch (filingStatus) {
       case FilingStatus.MFJ: {
         return 250000

--- a/src/data/urls.ts
+++ b/src/data/urls.ts
@@ -1,0 +1,32 @@
+const Urls = {
+  usTaxes: {
+    start: '/start'
+  },
+  taxPayer: {
+    root: '/taxpayer',
+    info: '/info',
+    spouseAndDependent: '/spouseanddependent',
+    contactInfo: '/contact'
+  },
+  refund: '/refundinfo',
+  questions: '/questions',
+  income: {
+    w2s: '/income/w2jobinfo',
+    f1099s: '/income/f1099s',
+    realEstate: '/income/realestate'
+  },
+  deductions: {
+    f1098es: '/deductions/studentloaninterest'
+  },
+  credits: {
+    main: '/credits',
+    eic: '/credits/eic'
+  },
+  createPdf: '/createpdf',
+  summary: '/summary',
+  default: ''
+}
+
+Urls.default = Urls.usTaxes.start
+
+export default Urls

--- a/src/hooks/Device.tsx
+++ b/src/hooks/Device.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react'
+import { useViewport } from './Viewport'
+import { useTheme } from '@material-ui/core/styles'
+
+interface DeviceProps {
+  isMobile: boolean
+}
+
+export const useDevice = (): DeviceProps => {
+  const { width } = useViewport()
+  const theme = useTheme()
+  const [isMobile, setIsMobile] = useState(theme.breakpoints.values.sm > width)
+
+  useEffect(() => {
+    setIsMobile(theme.breakpoints.values.sm > width)
+  }, [width])
+
+  return { isMobile }
+}

--- a/src/hooks/Device.tsx
+++ b/src/hooks/Device.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useViewport } from './Viewport'
 import { useTheme } from '@material-ui/core/styles'
 

--- a/src/hooks/Viewport.tsx
+++ b/src/hooks/Viewport.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, Context } from 'react'
+import React, { PropsWithChildren, Context, ReactElement } from 'react'
 
 interface Bounds {
   width: number
@@ -12,7 +12,9 @@ const getBounds = (): Bounds => ({
 
 export const viewportContext: Context<Bounds> = React.createContext(getBounds())
 
-export const ViewportProvider = ({ children }: PropsWithChildren<{}>) => {
+export const ViewportProvider = ({
+  children
+}: PropsWithChildren<Record<never, never>>): ReactElement => {
   const [bounds, setBounds] = React.useState(getBounds())
 
   const handleWindowResize = (): void => setBounds(getBounds())

--- a/src/hooks/Viewport.tsx
+++ b/src/hooks/Viewport.tsx
@@ -1,4 +1,12 @@
-import React, { PropsWithChildren, Context, ReactElement } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  PropsWithChildren,
+  Context,
+  ReactElement
+} from 'react'
 
 interface Bounds {
   width: number
@@ -10,16 +18,16 @@ const getBounds = (): Bounds => ({
   height: window.innerHeight
 })
 
-export const viewportContext: Context<Bounds> = React.createContext(getBounds())
+export const viewportContext: Context<Bounds> = createContext(getBounds())
 
 export const ViewportProvider = ({
   children
 }: PropsWithChildren<Record<never, never>>): ReactElement => {
-  const [bounds, setBounds] = React.useState(getBounds())
+  const [bounds, setBounds] = useState(getBounds())
 
   const handleWindowResize = (): void => setBounds(getBounds())
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('resize', handleWindowResize)
     return () => window.removeEventListener('resize', handleWindowResize)
   }, [])
@@ -31,4 +39,4 @@ export const ViewportProvider = ({
   )
 }
 
-export const useViewport = (): Bounds => React.useContext(viewportContext)
+export const useViewport = (): Bounds => useContext(viewportContext)

--- a/src/hooks/Viewport.tsx
+++ b/src/hooks/Viewport.tsx
@@ -1,10 +1,4 @@
-import React, {
-  PropsWithChildren,
-  ReactElement,
-  createContext,
-  useState,
-  Context
-} from 'react'
+import React, { PropsWithChildren, Context } from 'react'
 
 interface Bounds {
   width: number
@@ -16,7 +10,7 @@ const getBounds = (): Bounds => ({
   height: window.innerHeight
 })
 
-const viewportContext: Context<Bounds> = React.createContext(getBounds())
+export const viewportContext: Context<Bounds> = React.createContext(getBounds())
 
 export const ViewportProvider = ({ children }: PropsWithChildren<{}>) => {
   const [bounds, setBounds] = React.useState(getBounds())

--- a/src/index.js
+++ b/src/index.js
@@ -4,23 +4,26 @@ import { Provider } from 'react-redux'
 import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
 
 import { store, persistor } from './redux/store'
 import { PersistGate } from 'redux-persist/integration/react'
+import { ViewportProvider } from './hooks/Viewport'
 
 ReactDOM.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <PersistGate
-        loading={<h1>Loading from Local Storage</h1>}
-        persistor={persistor}
-      >
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </PersistGate>
-    </Provider>
+    <ViewportProvider>
+      <Provider store={store}>
+        <PersistGate
+          loading={<h1>Loading from Local Storage</h1>}
+          persistor={persistor}
+        >
+          <Router>
+            <App />
+          </Router>
+        </PersistGate>
+      </Provider>
+    </ViewportProvider>
   </React.StrictMode>,
   document.getElementById('root')
 )

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import './index.css'
@@ -11,7 +11,7 @@ import { PersistGate } from 'redux-persist/integration/react'
 import { ViewportProvider } from './hooks/Viewport'
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <ViewportProvider>
       <Provider store={store}>
         <PersistGate
@@ -24,7 +24,7 @@ ReactDOM.render(
         </PersistGate>
       </Provider>
     </ViewportProvider>
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById('root')
 )
 

--- a/src/irsForms/F1040.ts
+++ b/src/irsForms/F1040.ts
@@ -45,7 +45,7 @@ export enum F1040Error {
 
 export default class F1040 implements Form {
   tag: FormTag = 'f1040'
-  sequenceIndex: number = 0
+  sequenceIndex = 0
   // intentionally mirroring many fields from the state,
   // trying to represent the fields that the 1040 requires
   filingStatus?: FilingStatus

--- a/src/irsForms/F1040v.ts
+++ b/src/irsForms/F1040v.ts
@@ -4,7 +4,7 @@ import Form, { FormTag } from './Form'
 
 export default class F1040V implements Form {
   tag: FormTag = 'f1040v'
-  sequenceIndex: number = -1
+  sequenceIndex = -1
   state: Information
   f1040: F1040
 

--- a/src/irsForms/F8959.ts
+++ b/src/irsForms/F8959.ts
@@ -20,7 +20,7 @@ export const needsF8959 = (state: Information): boolean => {
 
 export default class F8959 implements Form {
   tag: FormTag = 'f8959'
-  sequenceIndex: number = 71
+  sequenceIndex = 71
   state: Information
   f4137?: F4137
   f8919?: F8919

--- a/src/irsForms/Form.ts
+++ b/src/irsForms/Form.ts
@@ -1,4 +1,4 @@
-import { Field, Fill } from '../pdfFiller'
+import { Fill } from '../pdfFiller'
 
 export type FormTag =
   | 'f1040'

--- a/src/irsForms/Schedule2.ts
+++ b/src/irsForms/Schedule2.ts
@@ -6,7 +6,7 @@ import F8959 from './F8959'
 
 export default class Schedule2 implements Form {
   tag: FormTag = 'f1040s2'
-  sequenceIndex: number = 2
+  sequenceIndex = 2
   tp: TaxPayer
   f8959?: F8959
 

--- a/src/irsForms/Schedule3.ts
+++ b/src/irsForms/Schedule3.ts
@@ -30,7 +30,7 @@ export const claimableExcessSSTaxWithholding = (w2s: IncomeW2[]): number => {
 
 export default class Schedule3 implements Form {
   tag: FormTag = 'f1040s3'
-  sequenceIndex: number = 3
+  sequenceIndex = 3
   state: Information
   f1040: F1040
 

--- a/src/irsForms/Schedule8812.ts
+++ b/src/irsForms/Schedule8812.ts
@@ -8,7 +8,7 @@ export default class Schedule8812 implements Form {
   tp: TaxPayer
   f1040: F1040
   tag: FormTag = 'f1040s8'
-  sequenceIndex: number = 47
+  sequenceIndex = 47
 
   constructor(tp: TP, f1040: F1040) {
     this.tp = new TaxPayer(tp)

--- a/src/irsForms/ScheduleB.ts
+++ b/src/irsForms/ScheduleB.ts
@@ -16,7 +16,7 @@ interface PayerAmount {
 
 export default class ScheduleB implements Form {
   tag: FormTag = 'f1040sb'
-  sequenceIndex: number = 8
+  sequenceIndex = 8
   state: Information
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16

--- a/src/irsForms/ScheduleD.ts
+++ b/src/irsForms/ScheduleD.ts
@@ -14,7 +14,7 @@ import SDUnrecaptured1250 from './worksheets/SDUnrecaptured1250'
 
 export default class ScheduleD implements Form {
   tag: FormTag = 'f1040sd'
-  sequenceIndex: number = 12
+  sequenceIndex = 12
   state: Information
   aggregated: F1099BData
   rateGainWorksheet: SDRateGainWorksheet

--- a/src/irsForms/ScheduleE.ts
+++ b/src/irsForms/ScheduleE.ts
@@ -44,7 +44,7 @@ const propTypeIndex = {
 
 export default class ScheduleE implements Form {
   tag: FormTag = 'f1040se'
-  sequenceIndex: number = 13
+  sequenceIndex = 13
   state: Information
   f6168: F6168
   f8582: F8582

--- a/src/irsForms/ScheduleEIC.ts
+++ b/src/irsForms/ScheduleEIC.ts
@@ -16,17 +16,17 @@ type PrecludesEIC<F> = (f: F) => boolean
 const unimplemented = (message: string): void =>
   log.warn(`[Schedule EIC] unimplemented ${message}`)
 
-const checks2555: PrecludesEIC<F2555> = (f): boolean => {
+const checks2555: PrecludesEIC<F2555> = (): boolean => {
   unimplemented('check F2555')
   return false
 }
 
-const checks4797: PrecludesEIC<F4797> = (f): boolean => {
+const checks4797: PrecludesEIC<F4797> = (): boolean => {
   unimplemented('check F4797')
   return false
 }
 
-const checks8814: PrecludesEIC<F8814> = (f): boolean => {
+const checks8814: PrecludesEIC<F8814> = (): boolean => {
   unimplemented('check F8814')
   return false
 }
@@ -45,15 +45,15 @@ const precludesEIC =
 
 export default class ScheduleEIC implements Form {
   tag: FormTag = 'f1040sei'
-  sequenceIndex: number = 43
+  sequenceIndex = 43
   tp: TaxPayer
   f2555?: F2555
   f4797?: F4797
   f8814?: F8814
   pub596Worksheet1: Pub596Worksheet1
-  qualifyingStudentCutoffYear: number = 1996
-  qualifyingCutoffYear: number = 2001
-  investmentIncomeLimit: number = 3650
+  qualifyingStudentCutoffYear = 1996
+  qualifyingCutoffYear = 2001
+  investmentIncomeLimit = 3650
   f1040: F1040
 
   constructor(tp: TP, f1040: F1040) {

--- a/src/irsForms/index.ts
+++ b/src/irsForms/index.ts
@@ -1,13 +1,10 @@
 import { PDFDocument } from 'pdf-lib'
 import { store } from '../redux/store'
-import Form from '../irsForms/Form'
 import { create1040 } from '../irsForms/Main'
 import { isLeft, zip } from '../util'
 import log from '../log'
-import { fillPDF } from '../pdfFiller/fillPdf'
 import { buildPdf, downloadPDF, savePDF } from '../pdfFiller/pdfHandler'
 import { Information } from '../redux/data'
-import { Fill } from '../pdfFiller'
 
 // opens new with filled information in the window of the component it is called from
 export async function create1040PDF(state: Information): Promise<Uint8Array> {

--- a/src/pdfFiller/fillPdf.ts
+++ b/src/pdfFiller/fillPdf.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, PDFCheckBox, PDFTextField, PDFRadioGroup } from 'pdf-lib'
+import { PDFDocument, PDFCheckBox, PDFTextField } from 'pdf-lib'
 import { Field } from '.'
 
 /**

--- a/src/pdfFiller/pdfHandler.ts
+++ b/src/pdfFiller/pdfHandler.ts
@@ -47,6 +47,7 @@ export async function savePDF(
   contents: Uint8Array,
   defaultFilename: string
 ): Promise<void> {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   if ((window as any).__TAURI__ === undefined) {
     // To set the download file name, we create a temporary link element,
     // use download property of an anchor tag, supported for most people
@@ -61,6 +62,7 @@ export async function savePDF(
     a.remove()
     return await Promise.resolve()
   } else {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     const defaultPath = await (window as any).__TAURI__.path.documentDir()
     const path = await save({
       filters: [{ name: 'PDF Documents (.pdf)', extensions: ['pdf'] }],

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -16,7 +16,6 @@ import {
   EditW2Action,
   Edit1098eAction,
   TaxesState,
-  State,
   StateResidency
 } from './data'
 import { ValidateFunction } from 'ajv'
@@ -73,7 +72,7 @@ type AddDependent = Save<typeof ActionName.ADD_DEPENDENT, Dependent>
 type EditDependent = Save<typeof ActionName.EDIT_DEPENDENT, EditDependentAction>
 type RemoveDependent = Save<typeof ActionName.REMOVE_DEPENDENT, number>
 type AddSpouse = Save<typeof ActionName.ADD_SPOUSE, Spouse>
-type RemoveSpouse = Save<typeof ActionName.REMOVE_SPOUSE, {}>
+type RemoveSpouse = Save<typeof ActionName.REMOVE_SPOUSE, Record<string, never>>
 type AddW2 = Save<typeof ActionName.ADD_W2, IncomeW2>
 type EditW2 = Save<typeof ActionName.EDIT_W2, EditW2Action>
 type RemoveW2 = Save<typeof ActionName.REMOVE_W2, number>
@@ -117,7 +116,9 @@ export type Actions =
 
 export type ActionCreator<A> = (formData: A) => Actions
 
-function signalAction<T extends ActionName>(t: T): Save<T, {}> {
+function signalAction<T extends ActionName>(
+  t: T
+): Save<T, Record<string, never>> {
   return {
     type: t,
     formData: {}
@@ -130,7 +131,7 @@ function signalAction<T extends ActionName>(t: T): Save<T, {}> {
  *  the schema at runtime so we can see errors if data of the wrong types
  *  about to be inserted into the model
  */
-function makeActionCreator<A extends Object, T extends ActionName>(
+function makeActionCreator<A, T extends ActionName>(
   t: T,
   validate: ValidateFunction<A>
 ): (formData: A) => Save<T, A> {
@@ -144,7 +145,7 @@ function makeActionCreator<A extends Object, T extends ActionName>(
  * This variant includes a preprocessor function that can be used to
  * apply formatting changes to provided data, for example.
  */
-function makePreprocessActionCreator<A extends Object, T extends ActionName>(
+function makePreprocessActionCreator<A, T extends ActionName>(
   t: T,
   validate: ValidateFunction<A>,
   clean: (d: A) => Partial<A>

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -10,12 +10,12 @@ import { PersistPartial } from 'redux-persist/es/persistReducer'
 
 const baseTransform = createTransform(
   // transform state on its way to being serialized and persisted.
-  (inboundState: Information, key) => {
+  (inboundState: Information) => {
     return inboundState
   },
   // transform state being rehydrated
   // Just ensure the state has all requisite root members
-  (outboundState: Information, key: keyof Information): Information => {
+  (outboundState: Information): Information => {
     return {
       ...blankState,
       ...outboundState
@@ -35,12 +35,14 @@ const persistedReducer = persistReducer<{ information: Information }, Actions>(
   rootReducer
 )
 
-export type InfoStore = Store<{ information: Information }> & { dispatch: {} }
+export type InfoStore = Store<{ information: Information }> & {
+  dispatch: unknown
+}
 export type PersistedStore = Store<
   { information: Information } & PersistPartial,
   Actions
 > & {
-  dispatch: {}
+  dispatch: unknown
 }
 
 export const createStoreUnpersisted = (information: Information): InfoStore =>

--- a/src/stateForms/Form.ts
+++ b/src/stateForms/Form.ts
@@ -1,4 +1,4 @@
-import { Field, Fill } from '../pdfFiller'
+import { Fill } from '../pdfFiller'
 import { State } from '../redux/data'
 
 /**

--- a/src/stateForms/IL/IL1040.ts
+++ b/src/stateForms/IL/IL1040.ts
@@ -27,7 +27,7 @@ export class IL1040 implements Form {
 
   attachments = (): Form[] => {
     const pmt = this.payment()
-    let result: Form[] = []
+    const result: Form[] = []
     if ((pmt ?? 0) > 0) {
       result.push(this.il1040V)
     }

--- a/src/stateForms/IL/IL1040ScheduleILEIC.ts
+++ b/src/stateForms/IL/IL1040ScheduleILEIC.ts
@@ -1,14 +1,8 @@
 import Form from '../Form'
 import F1040 from '../../irsForms/F1040'
 import { Field } from '../../pdfFiller'
-import { displayNumber, sumFields } from '../../irsForms/util'
-import {
-  AccountType,
-  Dependent,
-  FilingStatus,
-  Information,
-  State
-} from '../../redux/data'
+import { displayNumber } from '../../irsForms/util'
+import { Dependent, Information, State } from '../../redux/data'
 import parameters from './Parameters'
 
 export class il1040scheduleileeic implements Form {
@@ -16,7 +10,7 @@ export class il1040scheduleileeic implements Form {
   f1040: F1040
   formName: string
   state: State
-  formOrder: number = 1
+  formOrder = 1
   attachments: () => Form[] = () => []
   qualifyingDependents: Dependent[]
 

--- a/src/stateForms/IL/IL1040V.ts
+++ b/src/stateForms/IL/IL1040V.ts
@@ -2,8 +2,7 @@ import Form from '../Form'
 import F1040 from '../../irsForms/F1040'
 import { IL1040 } from './IL1040'
 import { Field } from '../../pdfFiller'
-import { displayNumber, sumFields } from '../../irsForms/util'
-import { AccountType, FilingStatus, Information, State } from '../../redux/data'
+import { Information, State } from '../../redux/data'
 
 export default class IL1040V implements Form {
   info: Information
@@ -11,7 +10,7 @@ export default class IL1040V implements Form {
   formName: string
   state: State
   il1040: IL1040
-  formOrder: number = -1
+  formOrder = -1
   attachments: () => Form[] = () => []
 
   constructor(info: Information, f1040: F1040, il1040: IL1040) {

--- a/src/testUtil.tsx
+++ b/src/testUtil.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import { BrowserRouter as Router } from 'react-router-dom'

--- a/src/testUtil.tsx
+++ b/src/testUtil.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react'
+import { render } from '@testing-library/react'
+
+import { BrowserRouter as Router } from 'react-router-dom'
+import { ViewportProvider } from 'ustaxes/hooks/Viewport'
+
+export const resizeWindow = (x: number, y: number) => {
+  global.innerWidth = x
+  global.innerHeight = y
+  window.dispatchEvent(new Event('resize'))
+}
+
+export const renderWithProviders = (ui: ReactElement) => ({
+  ...render(
+    <Router>
+      <ViewportProvider>{ui}</ViewportProvider>
+    </Router>
+  )
+})

--- a/src/testUtil.tsx
+++ b/src/testUtil.tsx
@@ -1,19 +1,18 @@
 import React, { ReactElement } from 'react'
-import { render } from '@testing-library/react'
+import { render, RenderResult } from '@testing-library/react'
 
 import { BrowserRouter as Router } from 'react-router-dom'
 import { ViewportProvider } from 'ustaxes/hooks/Viewport'
 
-export const resizeWindow = (x: number, y: number) => {
+export const resizeWindow = (x: number, y: number): void => {
   global.innerWidth = x
   global.innerHeight = y
   window.dispatchEvent(new Event('resize'))
 }
 
-export const renderWithProviders = (ui: ReactElement) => ({
-  ...render(
+export const renderWithProviders = (ui: ReactElement): RenderResult =>
+  render(
     <Router>
       <ViewportProvider>{ui}</ViewportProvider>
     </Router>
   )
-})

--- a/src/tests/ScheduleEIC.test.ts
+++ b/src/tests/ScheduleEIC.test.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-empty-function: "off" */
+
 import fc from 'fast-check'
 import { waitFor } from '@testing-library/react'
 import * as arbitraries from './arbitraries'
@@ -21,7 +23,7 @@ beforeAll(async () => jest.spyOn(console, 'warn').mockImplementation(() => {}))
 describe('ScheduleEIC', () => {
   it('should disallow EIC for income below threshold', () => {
     fc.assert(
-      fc.property(arbitraries.f1040, ([f1040, forms]) => {
+      fc.property(arbitraries.f1040, ([f1040]) => {
         if (f1040.filingStatus !== undefined) {
           const formula = federal.EIC.formulas[f1040.filingStatus]
           if (

--- a/src/tests/arbitraries.ts
+++ b/src/tests/arbitraries.ts
@@ -45,7 +45,7 @@ const state = fc.constantFrom(...locationPostalCodes.map(([, code]) => code))
 const concat = (
   as: Arbitrary<string>,
   bs: Arbitrary<string>,
-  sep: string = ' '
+  sep = ' '
 ): Arbitrary<string> => as.chain((a) => bs.map((b) => `${a}${sep}${b}`))
 
 // Ideally these would be normally distributed...

--- a/src/tests/components/Menu.test.tsx
+++ b/src/tests/components/Menu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import Menu, { drawerSections } from 'ustaxes/components/Menu'
 import { resizeWindow, renderWithProviders } from 'ustaxes/testUtil'
 

--- a/src/tests/components/Menu.test.tsx
+++ b/src/tests/components/Menu.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/react'
+import Menu, { drawerSections } from 'ustaxes/components/Menu'
+import { resizeWindow, renderWithProviders } from 'ustaxes/testUtil'
+
+const heading = drawerSections[0].title
+
+describe('Menu', () => {
+  beforeEach(() => {
+    renderWithProviders(<Menu />)
+  })
+  it('renders', () => {
+    expect(
+      screen.getByRole('button', { name: /open drawer/ })
+    ).toBeInTheDocument()
+  })
+  it('toggles open', async () => {
+    expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument()
+  })
+  describe('mobile view', () => {
+    beforeEach(async () => {
+      await waitFor(() => resizeWindow(400, 900))
+    })
+    it('renders', async () => {
+      expect(
+        screen.queryByRole('heading', { name: heading })
+      ).not.toBeInTheDocument()
+    })
+    it('closes with esc', async () => {
+      userEvent.click(screen.getByRole('button', { name: /open drawer/ }))
+      userEvent.type(screen.getByRole('heading', { name: heading }), '{esc}')
+      const headingElement = await screen.queryByRole('heading', {
+        name: heading
+      })
+      expect(headingElement).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/tests/components/Menu.test.tsx
+++ b/src/tests/components/Menu.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { screen, waitFor } from '@testing-library/react'
 import Menu, { drawerSections } from 'ustaxes/components/Menu'

--- a/src/tests/components/Questions.test.tsx
+++ b/src/tests/components/Questions.test.tsx
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-empty-function: "off" */
+
 import React, { ReactElement } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'

--- a/src/tests/components/Questions.test.tsx
+++ b/src/tests/components/Questions.test.tsx
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/no-empty-function: "off" */
 
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import Questions from 'ustaxes/components/Questions'

--- a/src/tests/components/SpouseAndDependent.test.tsx
+++ b/src/tests/components/SpouseAndDependent.test.tsx
@@ -136,8 +136,9 @@ describe('SpouseInfo', () => {
     userEvent.type(filledLastName, '{selectall}{del}McGee')
     fireEvent.change(filledSsn, { target: { value: '987-65-4321' } })
 
-    // wait for redux-persist to do some async stuff
-    await waitFor(() => {})
+    await waitFor(() => {
+      // wait for redux-persist to do some async stuff
+    })
 
     // click the save button to save the new values
     fireEvent.click(
@@ -201,8 +202,10 @@ describe('SpouseInfo', () => {
     userEvent.type(firstNameInput, 'F$LF(#)& ##3')
     fireEvent.click(saveButton)
 
-    // expect two input errors and an error about restricted characters
-    await waitFor(() => {})
+    await waitFor(() => {
+      // expect two input errors and an error about restricted characters
+    })
+
     const nameErrorsAfterBadFirstName = await screen.findAllByText(
       'Input is required'
     )
@@ -213,8 +216,9 @@ describe('SpouseInfo', () => {
     userEvent.type(firstNameInput, '{selectall}{del}Sally K')
     fireEvent.click(saveButton)
 
-    // expect two name errors
-    await waitFor(() => {})
+    await waitFor(() => {
+      // expect two name errors
+    })
     const nameErrorsAfterAddingFirstName = await screen.findAllByText(
       'Input is required'
     )
@@ -224,8 +228,9 @@ describe('SpouseInfo', () => {
     userEvent.type(lastNameInput, 'R5$%84')
     fireEvent.click(saveButton)
 
-    // expect an error about restricted characters, and one name error
-    await waitFor(() => {})
+    await waitFor(() => {
+      // expect an error about restricted characters, and one name error
+    })
     const nameErrorsAfterBadLastName = await screen.findAllByText(
       'Input is required'
     )
@@ -243,8 +248,9 @@ describe('SpouseInfo', () => {
     fireEvent.change(ssnInput, { target: { value: '123sc' } })
     fireEvent.click(saveButton)
 
-    // expect ssn error to remain
-    await waitFor(() => {})
+    await waitFor(() => {
+      // expect ssn error to remain
+    })
     await screen.findByText('Input should be filled with 9 digits')
 
     // clear ssn and add a valid value

--- a/src/tests/components/SpouseAndDependent.test.tsx
+++ b/src/tests/components/SpouseAndDependent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   render,
   screen,

--- a/src/tests/components/Taxpayer.test.tsx
+++ b/src/tests/components/Taxpayer.test.tsx
@@ -33,7 +33,14 @@ describe('Taxpayer', () => {
     const store = createStoreUnpersisted(info)
     const component = (
       <Provider store={store}>
-        <PagerContext.Provider value={{ onAdvance: () => {}, navButtons }}>
+        <PagerContext.Provider
+          value={{
+            onAdvance: () => {
+              /* do nothing */
+            },
+            navButtons
+          }}
+        >
           <TaxPayer />
         </PagerContext.Provider>
       </Provider>

--- a/src/tests/components/Taxpayer.test.tsx
+++ b/src/tests/components/Taxpayer.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 

--- a/src/tests/fica.test.ts
+++ b/src/tests/fica.test.ts
@@ -21,6 +21,7 @@ function hasAdditionalMedicareTax(f1040: F1040): boolean {
   return l8 !== undefined && l8 > 0
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type Constructor<T> = new (...args: any[]) => T
 function hasAttachment<FormType>(
   attachments: Form[],
@@ -69,7 +70,7 @@ describe('fica', () => {
 
   it('should give SS refund based on filing status', () => {
     fc.assert(
-      fc.property(arbitraries.f1040, ([f1040, forms]) => {
+      fc.property(arbitraries.f1040, ([f1040]) => {
         if (hasSSRefund(f1040)) {
           const s3l10 = f1040.schedule3?.l10()
           expect(s3l10).not.toBeUndefined()
@@ -109,7 +110,7 @@ describe('fica', () => {
 
   it('should add Additional Medicare Tax based on filing status', () => {
     fc.assert(
-      fc.property(arbitraries.f1040, ([f1040, forms]) => {
+      fc.property(arbitraries.f1040, ([f1040]) => {
         if (f1040.filingStatus === undefined) {
           return
         }

--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -1,7 +1,7 @@
 import * as fc from 'fast-check'
 import { Arbitrary } from 'fast-check'
 
-import { segments } from '../util'
+import { segments } from 'ustaxes/util'
 
 const segmentsArbitrary: Arbitrary<[string[], number]> = fc
   .array(fc.char(), { minLength: 1 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@
  * @returns tyepsafe array of keys
  */
 
-export const enumKeys = <A extends Object>(a: A): Array<keyof typeof a> =>
+export const enumKeys = <A>(a: A): Array<keyof typeof a> =>
   Object.keys(a).filter((k) => isNaN(Number(k))) as Array<keyof typeof a>
 
 export const anArrayOf = <A>(n: number, a: A): A[] =>
@@ -138,3 +138,8 @@ export const right = <E = never, A = never>(right: A): Either<E, A> => ({
 export const isLeft = <E, A>(e: Either<E, A>): e is Left<E> => e._tag === 'left'
 export const isRight = <E, A>(e: Either<E, A>): e is Right<A> =>
   e._tag === 'right'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isDesktop = (): boolean => (window as any).__TAURI__ !== undefined
+
+export const isWeb = (): boolean => !isDesktop()

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@
  * @param a Enumerator name
  * @returns tyepsafe array of keys
  */
+
 export const enumKeys = <A extends Object>(a: A): Array<keyof typeof a> =>
   Object.keys(a).filter((k) => isNaN(Number(k))) as Array<keyof typeof a>
 


### PR DESCRIPTION
Most notably this catches numerous unused imports and unused declared variables.

Many other rules catch questionable code, such as use of `{}`, object, any, String, Number as types. 

Removed `import React` per new recommended rules: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html