### PR TITLE
Fix missed update change for react-if

### DIFF
--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -273,16 +273,18 @@ const FormListContainer = <A,>(
         </Then>
         <Else>
           <If condition={max === undefined || items.length < max}>
-            <div className={classes.buttonList}>
-              <Button
-                type="button"
-                onClick={openAddForm}
-                color={prefersDarkMode ? 'default' : 'secondary'}
-                variant="contained"
-              >
-                Add
-              </Button>
-            </div>
+            <Then>
+              <div className={classes.buttonList}>
+                <Button
+                  type="button"
+                  onClick={openAddForm}
+                  color={prefersDarkMode ? 'default' : 'secondary'}
+                  variant="contained"
+                >
+                  Add
+                </Button>
+              </div>
+            </Then>
           </If>
         </Else>
       </If>

--- a/src/components/TaxPayer/Address.tsx
+++ b/src/components/TaxPayer/Address.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { If } from 'react-if'
+import { If, Then } from 'react-if'
 import {
   LabeledCheckbox,
   LabeledInput,
@@ -76,7 +76,9 @@ export default function AddressFields(props: AddressProps): ReactElement {
         patternConfig={Patterns.name}
       />
       <If condition={allowForeignCountry}>
-        <LabeledCheckbox label={checkboxText} name="isForeignCountry" />
+        <Then>
+          <LabeledCheckbox label={checkboxText} name="isForeignCountry" />
+        </Then>
       </If>
       {csz}
     </>

--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -15,7 +15,7 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
 import ListItemText from '@material-ui/core/ListItemText'
 import PersonIcon from '@material-ui/icons/Person'
-import { If } from 'react-if'
+import { If, Then } from 'react-if'
 
 export const PersonFields = ({
   children
@@ -54,11 +54,13 @@ export const PersonListItem = ({
       secondary={formatSSID(person.ssid)}
     />
     <If condition={editing !== undefined}>
-      <ListItemIcon>
-        <IconButton onClick={onEdit} edge="end" aria-label="edit">
-          <EditIcon />
-        </IconButton>
-      </ListItemIcon>
+      <Then>
+        <ListItemIcon>
+          <IconButton onClick={onEdit} edge="end" aria-label="edit">
+            <EditIcon />
+          </IconButton>
+        </ListItemIcon>
+      </Then>
     </If>
     <ListItemSecondaryAction>
       <IconButton onClick={remove} edge="end" aria-label="delete">

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -29,7 +29,7 @@ import { HouseOutlined } from '@material-ui/icons'
 import { FormListContainer } from 'ustaxes/components/FormContainer'
 import { Grid } from '@material-ui/core'
 import { CURRENT_YEAR } from 'ustaxes/data/federal'
-import { If } from 'react-if'
+import { If, Then } from 'react-if'
 import _ from 'lodash'
 
 interface PropertyAddForm {
@@ -230,11 +230,13 @@ export default function RealEstate(): ReactElement {
           valueMapping={(n) => n}
         />
         <If condition={propertyType === 'other'}>
-          <LabeledInput
-            name="otherPropertyType"
-            label="Short property type description"
-            required={true}
-          />
+          <Then>
+            <LabeledInput
+              name="otherPropertyType"
+              label="Short property type description"
+              required={true}
+            />
+          </Then>
         </If>
       </Grid>
       <h3>Use</h3>

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -27,7 +27,7 @@ import { FormListContainer } from 'ustaxes/components/FormContainer'
 import { Grid } from '@material-ui/core'
 import { Work } from '@material-ui/icons'
 import { addW2, editW2, removeW2 } from 'ustaxes/redux/actions'
-import { If } from 'react-if'
+import { If, Then } from 'react-if'
 import { Alert } from '@material-ui/lab'
 
 interface IncomeW2UserInput {
@@ -229,11 +229,13 @@ export default function W2JobInfo(): ReactElement {
     if (spouse !== undefined && spouseW2s.length > 0) {
       return (
         <If condition={filingStatus === FilingStatus.MFS}>
-          <Alert className="inner" severity="warning">
-            Filing status is set to Married Filing Separately.{' '}
-            <strong>{spouse.firstName}</strong>
-            &apos;s W2s will not be added to the return.
-          </Alert>
+          <Then>
+            <Alert className="inner" severity="warning">
+              Filing status is set to Married Filing Separately.{' '}
+              <strong>{spouse.firstName}</strong>
+              &apos;s W2s will not be added to the return.
+            </Alert>
+          </Then>
         </If>
       )
     }


### PR DESCRIPTION
Missed a change in the recent #605 for react-if

React-if now outputs console warnings if `<Then>` is not a child of `<If>`. This might be fine in Javascript, but in Typescript our goal is to turn runtime warnings into compile time errors. So we should probably remove react-if. For now this just applies the required change.