### PR TITLE
Run setup script with ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
-    "start": "node ./notice.js && node ./setup.js && craco start",
-    "build": "node ./setup.js && craco build",
-    "test": "node ./setup.js && craco test",
+    "start": "node ./notice.js && ts-node ./scripts/setup.ts && craco start",
+    "build": "ts-node ./scripts/setup.ts && craco build",
+    "test": "ts-node ./scripts/setup.ts && craco test",
     "eject": "craco eject",
+    "desktop-release": "ts-node ./scripts/setup.ts && tauri build",
+    "desktop": "node ./notice.js && ts-node ./scripts/setup.ts && tauri dev",
     "test:report": "npm run test -- --coverage .",
-    "desktop-release": "node ./setup.js && tauri build",
-    "desktop": "node ./notice.js && node ./setup.js && tauri dev",
     "tauri": "tauri",
     "schema-generate": "node ./setup.js",
     "lint": "eslint ./src --ext ts,js,tsx,jsx --max-warnings=0 && prettier -c .",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,5 +1,5 @@
-const tsj = require('ts-json-schema-generator')
-const fs = require('fs')
+import { createGenerator } from 'ts-json-schema-generator'
+import fs from 'fs'
 
 const config = {
   path: 'src/redux/data.ts',
@@ -9,8 +9,8 @@ const config = {
 
 const outputPath = 'src/redux/validation.json'
 
-const schema = tsj.createGenerator(config).createSchema(config.type)
+const schema = createGenerator(config).createSchema(config.type)
 const schemaString = JSON.stringify(schema, null, 2)
-fs.writeFile(outputPath, schemaString, (err) => {
+fs.writeFile(outputPath, schemaString, (err): void => {
   if (err) throw err
 })


### PR DESCRIPTION
Setup script compiles our runtime data schema definitions. This just moves it into a script folder and runs it as typescript code.

**What kind of change does this PR introduce?** (delete not applicable)
- Refactor
- Build-related changes
