### PR TITLE
Fix floating point errors in PDFs

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -29,6 +29,7 @@ import Questions from './Questions'
 import Urls from 'ustaxes/data/urls'
 
 import { isMobile } from 'react-device-detect'
+import { makeDownloader } from 'ustaxes/pdfFiller/pdfHandler'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -60,6 +61,8 @@ const useStyles = makeStyles((theme: Theme) =>
     }
   })
 )
+
+const downloader = makeDownloader('')
 
 const getTitleAndPage = (sections: Section[], currentUrl: string): string => {
   const page = sections
@@ -112,7 +115,11 @@ export const drawerSections: Section[] = [
     items: [
       item('Refund Information', Urls.refund, <RefundBankAccount />),
       item('Informational Questions', Urls.questions, <Questions />),
-      item('Review and Print', Urls.createPdf, <CreatePDF />)
+      item(
+        'Review and Print',
+        Urls.createPdf,
+        <CreatePDF downloader={downloader} />
+      )
     ]
   }
 ]

--- a/src/irsForms/Form.ts
+++ b/src/irsForms/Form.ts
@@ -1,4 +1,4 @@
-import { Field, Fill } from '../pdfFiller'
+import Fill from 'ustaxes/pdfFiller/Fill'
 
 export type FormTag =
   | 'f1040'
@@ -31,13 +31,11 @@ export type FormTag =
  * Any PDF can be filled from an array of values.
  *
  */
-export default abstract class Form implements Fill {
+export default abstract class Form extends Fill {
   // Match the filename without extension when downloaded from IRS
   abstract tag: FormTag
   // Match the sequence number in the header of the PDF.
   abstract sequenceIndex: number
-
-  abstract fields: () => Field[]
 
   public toString = (): string => `
     Form ${this.tag}, at sequence ${this.sequenceIndex}

--- a/src/irsForms/index.ts
+++ b/src/irsForms/index.ts
@@ -4,33 +4,48 @@ import { create1040 } from '../irsForms/Main'
 import { isLeft } from '../util'
 import _ from 'lodash'
 import log from '../log'
-import { buildPdf, downloadPDF, savePDF } from '../pdfFiller/pdfHandler'
+import {
+  combinePdfs,
+  getPdfs,
+  PDFDownloader,
+  savePDF
+} from '../pdfFiller/pdfHandler'
 import { Information } from '../redux/data'
 
-// opens new with filled information in the window of the component it is called from
-export async function create1040PDF(state: Information): Promise<Uint8Array> {
-  if (state.taxPayer !== undefined) {
-    const f1040Result = create1040(state)
-    // Get data and pdf links applicable to the model state
-    if (isLeft(f1040Result)) {
-      return await Promise.reject(f1040Result.left)
+export const create1040PDFs =
+  (state: Information) =>
+  async (downloader: PDFDownloader): Promise<PDFDocument[]> => {
+    if (state.taxPayer !== undefined) {
+      const f1040Result = create1040(state)
+      // Get data and pdf links applicable to the model state
+      if (isLeft(f1040Result)) {
+        return await Promise.reject(f1040Result.left)
+      }
+
+      const [, forms] = f1040Result.right
+
+      const pdfs: PDFDocument[] = await Promise.all(
+        forms.map(async (f) => await downloader(`/forms/${f.tag}.pdf`))
+      )
+
+      return getPdfs(_.zipWith(forms, pdfs, (a, b) => [a, b]))
     }
 
-    const [, forms] = f1040Result.right
-
-    const pdfs: PDFDocument[] = await Promise.all(
-      forms.map(async (f) => await downloadPDF(`/forms/${f.tag}.pdf`))
-    )
-
-    return buildPdf(_.zipWith(forms, pdfs, (a, b) => [a, b]))
+    log.error('Attempt to create pdf with no data, will be empty')
+    return []
   }
 
-  log.error('Attempt to create pdf with no data, will be empty')
-  return new Uint8Array()
-}
+export const create1040PDF =
+  (state: Information) =>
+  async (downloader: PDFDownloader): Promise<Uint8Array> =>
+    (await combinePdfs(await create1040PDFs(state)(downloader))).save()
 
 // opens new with filled information in the window of the component it is called from
-export async function createPDFPopup(defaultFilename: string): Promise<void> {
-  const pdfBytes = await create1040PDF(store.getState().information)
-  return await savePDF(pdfBytes, defaultFilename)
-}
+export const createPDFPopup =
+  (defaultFilename: string) =>
+  async (downloader: PDFDownloader): Promise<void> => {
+    const pdfBytes = await create1040PDF(store.getState().information)(
+      downloader
+    )
+    return await savePDF(pdfBytes, defaultFilename)
+  }

--- a/src/pdfFiller/Fill.ts
+++ b/src/pdfFiller/Fill.ts
@@ -1,0 +1,20 @@
+import { Field, RenderedField } from '.'
+
+export const fieldIsNumber = (field: Field): field is number =>
+  typeof field === 'number' || (!Number.isNaN(field) && Number.isFinite(field))
+
+export default abstract class Fill {
+  abstract fields: () => Field[]
+
+  renderedFields = (): RenderedField[] =>
+    this.fields().map((field) => {
+      if (fieldIsNumber(field)) {
+        if (Number.isInteger(field)) {
+          return field.toString()
+        }
+        return field.toFixed(2).toString()
+      } else {
+        return field
+      }
+    })
+}

--- a/src/pdfFiller/index.ts
+++ b/src/pdfFiller/index.ts
@@ -1,5 +1,2 @@
 export type Field = string | number | boolean | undefined
-
-export interface Fill {
-  fields: () => Field[]
-}
+export type RenderedField = string | boolean | undefined

--- a/src/pdfFiller/pdfHandler.ts
+++ b/src/pdfFiller/pdfHandler.ts
@@ -2,7 +2,7 @@ import { save } from '@tauri-apps/api/dialog'
 import { writeBinaryFile } from '@tauri-apps/api/fs'
 import fetch from 'node-fetch'
 import { PDFDocument } from 'pdf-lib'
-import { Fill } from '.'
+import Fill from './Fill'
 import { fillPDF } from './fillPdf'
 
 export interface PDFDownloader {
@@ -36,7 +36,7 @@ export const getPdfs = async (
   // Insert the values from each field into the PDF
   const pdfFiles: Array<Promise<PDFDocument>> = formData.map(
     async ([data, f]) => {
-      fillPDF(f, data.fields())
+      fillPDF(f, data.renderedFields())
       const pageBytes = await f.save()
       return await PDFDocument.load(pageBytes)
     }

--- a/src/stateForms/Form.ts
+++ b/src/stateForms/Form.ts
@@ -1,17 +1,17 @@
 import F1040 from 'ustaxes/irsForms/F1040'
-import { Fill } from '../pdfFiller'
+import Fill from 'ustaxes/pdfFiller/Fill'
 import { IncomeW2, Information, State } from '../redux/data'
 
 /**
  * Represents a state's income tax form, or schedule
  */
-export default interface Form extends Fill {
-  state: State
-  formName: string
-  formOrder: number
-  attachments: () => Form[]
-  info: Information
-  f1040: F1040
+export default abstract class Form extends Fill {
+  abstract state: State
+  abstract formName: string
+  abstract formOrder: number
+  abstract attachments: () => Form[]
+  abstract info: Information
+  abstract f1040: F1040
 }
 
 /**

--- a/src/stateForms/IL/IL1040.ts
+++ b/src/stateForms/IL/IL1040.ts
@@ -1,29 +1,30 @@
 import Form, { FormMethods } from '../Form'
 import F1040 from '../../irsForms/F1040'
-import { Field } from '../../pdfFiller'
+import { Field } from 'ustaxes/pdfFiller'
 import { displayNumber, sumFields } from '../../irsForms/util'
 import { AccountType, FilingStatus, Information, State } from '../../redux/data'
 import parameters from './Parameters'
-import { il1040scheduleileeic } from './IL1040ScheduleILEIC'
+import { IL1040scheduleileeic } from './IL1040ScheduleILEIC'
 import IL1040V from './IL1040V'
 import { ILWIT } from './ILWit'
 
-export class IL1040 implements Form {
+export class IL1040 extends Form {
   info: Information
   f1040: F1040
   formName: string
   state: State
-  scheduleEIC: il1040scheduleileeic
+  scheduleEIC: IL1040scheduleileeic
   il1040V: IL1040V
   formOrder = 0
   methods: FormMethods
 
   constructor(info: Information, f1040: F1040) {
+    super()
     this.info = info
     this.f1040 = f1040
     this.formName = 'IL-1040'
     this.state = 'IL'
-    this.scheduleEIC = new il1040scheduleileeic(info, f1040)
+    this.scheduleEIC = new IL1040scheduleileeic(info, f1040)
     this.il1040V = new IL1040V(info, f1040, this)
     this.methods = new FormMethods(this)
   }

--- a/src/stateForms/IL/IL1040ScheduleILEIC.ts
+++ b/src/stateForms/IL/IL1040ScheduleILEIC.ts
@@ -1,11 +1,11 @@
-import Form from '../Form'
-import F1040 from '../../irsForms/F1040'
-import { Field } from '../../pdfFiller'
+import Form from 'ustaxes/stateForms/Form'
+import F1040 from 'ustaxes/irsForms/F1040'
+import { Field } from 'ustaxes/pdfFiller'
 import { displayNumber } from '../../irsForms/util'
 import { Dependent, Information, State } from '../../redux/data'
 import parameters from './Parameters'
 
-export class il1040scheduleileeic implements Form {
+export class IL1040scheduleileeic extends Form {
   info: Information
   f1040: F1040
   formName: string
@@ -15,6 +15,7 @@ export class il1040scheduleileeic implements Form {
   qualifyingDependents: Dependent[]
 
   constructor(info: Information, f1040: F1040) {
+    super()
     this.info = info
     this.f1040 = f1040
     this.formName = 'il-1040-schedule-il-e-eic'
@@ -1838,6 +1839,6 @@ export class il1040scheduleileeic implements Form {
 const makeil1040scheduleileeic = (
   info: Information,
   f1040: F1040
-): il1040scheduleileeic => new il1040scheduleileeic(info, f1040)
+): IL1040scheduleileeic => new IL1040scheduleileeic(info, f1040)
 
 export default makeil1040scheduleileeic

--- a/src/stateForms/IL/IL1040V.ts
+++ b/src/stateForms/IL/IL1040V.ts
@@ -1,10 +1,10 @@
 import Form from '../Form'
 import F1040 from '../../irsForms/F1040'
 import { IL1040 } from './IL1040'
-import { Field } from '../../pdfFiller'
+import { Field } from 'ustaxes/pdfFiller'
 import { Information, State } from '../../redux/data'
 
-export default class IL1040V implements Form {
+export default class IL1040V extends Form {
   info: Information
   f1040: F1040
   formName: string
@@ -14,6 +14,7 @@ export default class IL1040V implements Form {
   attachments: () => Form[] = () => []
 
   constructor(info: Information, f1040: F1040, il1040: IL1040) {
+    super()
     this.info = info
     this.f1040 = f1040
     this.formName = 'IL-1040-V'

--- a/src/stateForms/IL/ILWit.ts
+++ b/src/stateForms/IL/ILWit.ts
@@ -1,6 +1,6 @@
 import Form, { FormMethods } from '../Form'
 import F1040 from '../../irsForms/F1040'
-import { Field } from '../../pdfFiller'
+import { Field } from 'ustaxes/pdfFiller'
 import { IncomeW2, Information, PersonRole, State } from '../../redux/data'
 import _ from 'lodash'
 
@@ -49,7 +49,7 @@ const toWithholdingForm = (w2: IncomeW2): WithholdingForm | undefined => {
  * primary taxpayer and 5 for spouse
  * TODO: support more than 5 for each
  */
-export class ILWIT implements Form {
+export class ILWIT extends Form {
   info: Information
   f1040: F1040
   formName = 'IL-WIT'
@@ -61,6 +61,7 @@ export class ILWIT implements Form {
   static WITHHOLDING_FORMS_PER_PAGE = 5
 
   constructor(info: Information, f1040: F1040, subFormIndex = 0) {
+    super()
     this.info = info
     this.f1040 = f1040
     this.methods = new FormMethods(this)

--- a/src/tests/components/income/F1099Info.test.tsx
+++ b/src/tests/components/income/F1099Info.test.tsx
@@ -83,7 +83,7 @@ describe('F1099Info', () => {
     selectOption: (labelText: string | RegExp, input: string) => void
     buttonClick: (buttonText: string) => void
   } => {
-    const store = createStoreUnpersisted(info)
+    const store = createStoreUnpersisted({ information: info })
     const navButtons = <PagerButtons submitText="Save and Continue" />
 
     render(

--- a/src/tests/pdfFiller/pdfHandler.test.ts
+++ b/src/tests/pdfFiller/pdfHandler.test.ts
@@ -1,0 +1,96 @@
+import * as fc from 'fast-check'
+import { PDFDocument, PDFField, PDFTextField } from 'pdf-lib'
+import { create1040PDFs } from 'ustaxes/irsForms'
+import * as arbitraries from 'ustaxes/tests/arbitraries'
+import { PDFDownloader } from 'ustaxes/pdfFiller/pdfHandler'
+import fs from 'fs'
+import path from 'path'
+import { Information } from 'ustaxes/redux/data'
+
+jest.setTimeout(120 * 1000)
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  // PDF-lib creates console warning on every creation due to no XFA support
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+const files: { [key: string]: PDFDocument } = {}
+
+const downloader: PDFDownloader = async (url: string): Promise<PDFDocument> => {
+  const p = path.join(__dirname, '../../../public', url)
+
+  if (p in files) {
+    return files[p].copy()
+  }
+
+  const pdfBytes: Uint8Array = await new Promise((resolve, reject) =>
+    fs.readFile(p, null, (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  )
+
+  const pdf = await PDFDocument.load(pdfBytes.buffer)
+  files[p] = pdf
+  return pdf
+}
+
+const findBadDecimalFormat = (
+  field: PDFField
+): [string, string] | undefined => {
+  if (field instanceof PDFTextField) {
+    const text = field.getText()
+    if (text !== undefined && !isNaN(Number(text))) {
+      const numberParts = text.split('.')
+      if (numberParts.length === 2 && numberParts[1].length !== 2) {
+        return [field.getName(), text]
+      }
+    }
+  }
+}
+
+/**
+ * Run a test for a given return, and report on [pdf title, [fieldName, testResult]] for
+ * each field that has a malformatted number.
+ */
+const testEveryField = async <A>(
+  info: Information,
+  fieldMatch: (field: PDFField) => A | undefined
+): Promise<[string, [number, A][]][]> => {
+  const schedules: PDFDocument[] = await create1040PDFs(info)(downloader)
+  return schedules.flatMap((pdf, i) => {
+    const pdfBadFields: [number, A][] = pdf
+      .getForm()
+      .getFields()
+      .flatMap((field, i) => {
+        const fieldValue = fieldMatch(field)
+        if (fieldValue !== undefined) {
+          return [[i, fieldValue]]
+        }
+        return []
+      })
+
+    if (pdfBadFields.length > 0) {
+      return [[pdf.getTitle() ?? `pdf-${i}`, pdfBadFields]]
+    } else {
+      return []
+    }
+  })
+}
+
+describe('pdfHandler', async () => {
+  it('every field has only two decimal places max', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitraries.information, async (info) => {
+        expect(await testEveryField(info, findBadDecimalFormat)).toHaveLength(0)
+      }),
+      {
+        interruptAfterTimeLimit: 100 * 1000 // 100 seconds
+      }
+    )
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix
- Refactor

Rounding formatting errors are present in PDF fields with numeric values. `.30000000004` style errors as well as string formatting such as `123.6` are also present.

This also refactors things somewhat so we can provide a different downloader in testing. This will also be useful in #686 where pdfs are downloaded from ustaxes.org instead of from the testing machine file system.

See 611de2a for output from failing test.
