### PR TITLE
State migrations for hydration and loading files

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -112,7 +112,7 @@ export const drawerSections: Section[] = [
     title: 'Savings Accounts',
     items: [
       item(
-        'Health Savings Accout (HSA)',
+        'Health Savings Account (HSA)',
         Urls.savingsAccounts.healthSavingsAccounts,
         <HealthSavingsAccounts />
       )

--- a/src/redux/fs/FSReducer.ts
+++ b/src/redux/fs/FSReducer.ts
@@ -12,7 +12,7 @@ import { FSAction } from './Actions'
  * It will overwrite whatever state exists with whatever
  * state it finds, but needs none of its own state.
  */
-const fsReducer = <S, A extends AnyAction>(
+const fsReducer = <S extends YearsTaxesState, A extends AnyAction>(
   filename: string,
   reducer: Reducer<S, A>
 ): Reducer<S, A & FSAction<S>> => {
@@ -23,7 +23,7 @@ const fsReducer = <S, A extends AnyAction>(
       case 'fs/recover': {
         return {
           ...newState,
-          ...migrateEachYear(action.data as unknown as YearsTaxesState)
+          ...migrateEachYear(action.data)
         }
       }
       case 'fs/persist': {

--- a/src/redux/fs/FSReducer.ts
+++ b/src/redux/fs/FSReducer.ts
@@ -1,7 +1,7 @@
 import { AnyAction, Reducer } from 'redux'
 import { download } from '.'
-import { YearsTaxesState } from '..'
 import { migrateEachYear } from '../migration'
+import { USTPersistedState } from '../store'
 import { FSAction } from './Actions'
 
 /**
@@ -12,7 +12,7 @@ import { FSAction } from './Actions'
  * It will overwrite whatever state exists with whatever
  * state it finds, but needs none of its own state.
  */
-const fsReducer = <S extends YearsTaxesState, A extends AnyAction>(
+const fsReducer = <S extends USTPersistedState, A extends AnyAction>(
   filename: string,
   reducer: Reducer<S, A>
 ): Reducer<S, A & FSAction<S>> => {

--- a/src/redux/fs/FSReducer.ts
+++ b/src/redux/fs/FSReducer.ts
@@ -1,5 +1,7 @@
 import { AnyAction, Reducer } from 'redux'
 import { download } from '.'
+import { YearsTaxesState } from '..'
+import { migrateEachYear } from '../migration'
 import { FSAction } from './Actions'
 
 /**
@@ -21,7 +23,7 @@ const fsReducer = <S, A extends AnyAction>(
       case 'fs/recover': {
         return {
           ...newState,
-          ...action.data
+          ...migrateEachYear(action.data as unknown as YearsTaxesState)
         }
       }
       case 'fs/persist': {

--- a/src/redux/migration.ts
+++ b/src/redux/migration.ts
@@ -1,14 +1,14 @@
 import { enumKeys } from 'ustaxes/core/util'
 import { TaxYears } from 'ustaxes/data'
-import { YearsTaxesState } from '.'
 import { blankState } from './reducer'
+import { USTPersistedState } from './store'
 
 /**
  * Ensures all default fields are present on each year's data
  * @returns state, mutated
  */
-export function migrateEachYear<S extends YearsTaxesState>(state: S): S {
-  return enumKeys(TaxYears).reduce(
+export const migrateEachYear = <S extends USTPersistedState>(state: S): S =>
+  enumKeys(TaxYears).reduce(
     (acc, year) => ({
       ...acc,
       [year]: {
@@ -18,4 +18,3 @@ export function migrateEachYear<S extends YearsTaxesState>(state: S): S {
     }),
     state
   )
-}

--- a/src/redux/migration.ts
+++ b/src/redux/migration.ts
@@ -7,13 +7,15 @@ import { blankState } from './reducer'
  * Ensures all default fields are present on each year's data
  * @returns state, mutated
  */
-export function migrateEachYear(state: YearsTaxesState) {
-  for (const year of enumKeys(TaxYears)) {
-    // copy default fields into each year's data
-    state[year] = {
-      ...blankState,
-      ...state[year]
-    }
-  }
-  return state
+export function migrateEachYear<S extends YearsTaxesState>(state: S): S {
+  return enumKeys(TaxYears).reduce(
+    (acc, year) => ({
+      ...acc,
+      [year]: {
+        ...blankState,
+        ...acc[year]
+      }
+    }),
+    state
+  )
 }

--- a/src/redux/migration.ts
+++ b/src/redux/migration.ts
@@ -1,0 +1,19 @@
+import { enumKeys } from 'ustaxes/core/util'
+import { TaxYears } from 'ustaxes/data'
+import { YearsTaxesState } from '.'
+import { blankState } from './reducer'
+
+/**
+ * Ensures all default fields are present on each year's data
+ * @returns state, mutated
+ */
+export function migrateEachYear(state: YearsTaxesState) {
+  for (const year of enumKeys(TaxYears)) {
+    // copy default fields into each year's data
+    state[year] = {
+      ...blankState,
+      ...state[year]
+    }
+  }
+  return state
+}

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,9 +5,9 @@ import {
   CombinedState
 } from 'redux'
 import logger from 'redux-logger'
-import rootReducer, { blankState } from './reducer'
+import rootReducer from './reducer'
 
-import { persistStore, persistReducer, createTransform } from 'redux-persist'
+import { persistStore, persistReducer, createMigrate } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
 import { Information } from 'ustaxes/core/data'
 import { blankYearTaxesState, YearsTaxesState } from '.'
@@ -15,33 +15,31 @@ import { Actions } from './actions'
 import { PersistPartial } from 'redux-persist/es/persistReducer'
 import { FSAction } from './fs/Actions'
 import fsReducer from './fs/FSReducer'
+import { migrateEachYear } from './migration'
 
-const baseTransform = createTransform(
-  // transform state on its way to being serialized and persisted.
-  (inboundState: Information) => {
-    return inboundState
-  },
-  // transform state being rehydrated
-  // Just ensure the state has all requisite root members
-  (outboundState: Information): Information => {
-    return {
-      ...blankState,
-      ...outboundState
-    }
-  },
-  { whitelist: ['information'] }
-)
-
-const persistConfig = {
-  key: 'root',
-  storage,
-  transforms: [baseTransform]
-}
+/**
+ * Each key of these migrations will only run if it is less than the current version.
+ * Even though this is a general purpose migration function that should handle most changes,
+ * a new key will need to be added here with each change to the state shape.
+ **/
+const migrate = createMigrate({
+  '0': (state) => {
+    // this type dance is unfortunate, but createMigrate isn't typed generically...
+    const migrated = migrateEachYear(state as unknown as YearsTaxesState)
+    return migrated as unknown as typeof state
+  }
+})
 
 const persistedReducer = fsReducer(
   'ustaxes_save.json',
   persistReducer<CombinedState<YearsTaxesState>, Actions>(
-    persistConfig,
+    {
+      key: 'root',
+      storage,
+      migrate,
+      // increment version each time anything is changed about the app's state, otherwise migrations don't run
+      version: 0
+    },
     rootReducer
   )
 )

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -7,7 +7,7 @@ import {
 import logger from 'redux-logger'
 import rootReducer from './reducer'
 
-import { persistStore, persistReducer, PersistState } from 'redux-persist'
+import { persistStore, persistReducer, PersistedState } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
 import { Information } from 'ustaxes/core/data'
 import { blankYearTaxesState, YearsTaxesState } from '.'
@@ -17,7 +17,7 @@ import { FSAction } from './fs/Actions'
 import fsReducer from './fs/FSReducer'
 import { migrateEachYear } from './migration'
 
-export type USTPersistedState = { _persist: PersistState } & YearsTaxesState
+export type USTPersistedState = NonNullable<PersistedState> & YearsTaxesState
 
 const migrate = async (state: USTPersistedState): Promise<USTPersistedState> =>
   migrateEachYear(state)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

This uses the built-in migrations feature of `redux-persist` to migrate the state shape to the latest whenever it is hydrated. (I believe the initial code from #130 may have never worked.) It also uses a shared function to do the same when loading from a JSON file so older files will continue to function with upgrades to the app.

The migrations feature of `redux-persist` depends on a versioning scheme which is a bit overkill for where this app is at the moment, but I think it will be useful in the long run. We just need to be vigilant about bumping the version and including a migration step for each change to the state interface.

(Also fixes a typo in the menu.)

*Maintainer note*:
Fixes an error thrown if localStorage is missing parameters currently expected, due to version updates. Reproducing on master:
```ts
let store = JSON.parse(window.localStorage["persist:root"])
let y2020 = JSON.parse(store.Y2020)
y2020.healthSavingsAccounts = undefined
store.Y2020 = JSON.stringify(y2020)
window.localStorage["persist:root"] = JSON.stringify(store)
```
Will throw an error after switching to Health Savings Account tab.
