### PR TITLE
Make dependabot PR against master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: "dependabot-updates-minor"
+    target-branch: "master"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -21,7 +21,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: "dependabot-updates-major"
+    target-branch: "master"
     ignore:
       # We're holding react-router-dom, 
       # 5->6 is a big api change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,6 @@ permissions:
   contents: write
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: ['16']
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-      # install dependencies
-    - run: npm ci
-
-    - name: Run ESLint
-      run: npm run lint
-
   test:
     runs-on: ubuntu-latest
 
@@ -45,6 +26,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
       # installs dependencies
     - run: npm ci
+      # build
+    - name: Run ESLint
+      run: npm run lint
+    - name: Ensure project builds
+      run: npm run build
       # run tests
     - name: Run jest unit tests
       run: npm run test:report
@@ -56,7 +42,7 @@ jobs:
         verbose: true
 
   dependabot-auto-merge:
-    needs: [lint, test]
+    needs: [test]
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, dependabot-updates-minor ]
+    branches: [ master ]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
For minor updates, automerge on passing CI.

For major updates, run CI but no automerge

I think we should only deploy to netlify on major updates, will need to change netlify settings and deploy from github actions probably.