### PR TITLE
Fix box 12 formatting and incorrect medicare wages assumption

### DIFF
--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, ReactNode, useState } from 'react'
+import _ from 'lodash'
 import { useDispatch, useSelector, TaxesState } from 'ustaxes/redux'
 import { Helmet } from 'react-helmet'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
@@ -31,7 +32,11 @@ import { Grid, Box, Button, Paper } from '@material-ui/core'
 import { Work } from '@material-ui/icons'
 import { addW2, editW2, removeW2 } from 'ustaxes/redux/actions'
 import { Alert } from '@material-ui/lab'
-import { enumKeys, parseFormNumberOrThrow } from 'ustaxes/core/util'
+import {
+  enumKeys,
+  parseFormNumber,
+  parseFormNumberOrThrow
+} from 'ustaxes/core/util'
 
 interface IncomeW2UserInput {
   employer?: Employer
@@ -45,7 +50,7 @@ interface IncomeW2UserInput {
   state?: State
   stateWages: string
   stateWithholding: string
-  box12: W2Box12Info
+  box12: W2Box12Info<string>
 }
 
 const blankW2UserInput: IncomeW2UserInput = {
@@ -76,7 +81,8 @@ const toIncomeW2 = (formData: IncomeW2UserInput): IncomeW2 => ({
   state: formData.state,
   stateWages: parseFormNumberOrThrow(formData.stateWages),
   stateWithholding: parseFormNumberOrThrow(formData.stateWithholding),
-  personRole: formData.personRole ?? PersonRole.PRIMARY
+  personRole: formData.personRole ?? PersonRole.PRIMARY,
+  box12: _.mapValues(formData.box12, (v) => parseFormNumber(v))
 })
 
 const toIncomeW2UserInput = (data: IncomeW2): IncomeW2UserInput => ({
@@ -89,7 +95,8 @@ const toIncomeW2UserInput = (data: IncomeW2): IncomeW2UserInput => ({
   medicareWithholding: data.medicareWithholding.toString(),
   state: data.state,
   stateWages: data.stateWages?.toString() ?? '',
-  stateWithholding: data.stateWithholding?.toString() ?? ''
+  stateWithholding: data.stateWithholding?.toString() ?? '',
+  box12: _.mapValues(data.box12, (v) => v?.toString())
 })
 
 const Box12Data = (): ReactElement => {
@@ -135,8 +142,8 @@ const Box12Data = (): ReactElement => {
         .filter((code) => box12[code] !== undefined)
         .map((code) => (
           <li key={`box-12-data-${code}`}>
-            {code}: <Currency plain value={box12[code] as number} /> (
-            {W2Box12CodeDescriptions[code]})
+            {code}: <Currency plain value={parseFormNumber(box12[code]) ?? 0} />{' '}
+            ({W2Box12CodeDescriptions[code]})
           </li>
         ))}
     </ul>

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useState } from 'react'
+import { Fragment, ReactElement, ReactNode, useState } from 'react'
 import _ from 'lodash'
 import { useDispatch, useSelector, TaxesState } from 'ustaxes/redux'
 import { Helmet } from 'react-helmet'
@@ -109,18 +109,17 @@ const Box12Data = (): ReactElement => {
   const box12Fields = (
     <>
       {enumKeys(W2Box12Code).map((code) => (
-        <>
+        <Fragment key={`box-12-${code}`}>
           <p>
             <strong>Code {code}</strong>: {W2Box12CodeDescriptions[code]}
           </p>
           <LabeledInput
             label={code}
-            key={`box-12{$code}`}
             name={`box12.${code}`}
             patternConfig={Patterns.currency}
             required={false}
           />
-        </>
+        </Fragment>
       ))}
     </>
   )
@@ -270,7 +269,7 @@ export default function W2JobInfo(): ReactElement {
           sizes={{ xs: 12, lg: 6 }}
         />
         <USStateDropDown name="state" label={boxLabel('15', 'State')} />
-        <Grid item xs={12} spacing={2}>
+        <Grid item xs={12} lg={12}>
           <Box12Data />
         </Grid>
         <LabeledInput

--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -181,7 +181,7 @@ export const W2Box12CodeDescriptions: { [key in W2Box12Code]: string } = {
   A: 'Uncollected social security or RRTA tax on tips.',
   B: 'Uncollected Medicare tax on tips.',
   C: 'Taxable cost of group-term life insurance over $50,000.',
-  D: 'Elective deferrals under a section 401(k) cash or deferred arrangement (plan).',
+  D: 'Elective deferrals under a section 401(k) cash or deferred arrangement plan.',
   E: 'Elective deferrals under a section 403(b) salary reduction agreement.',
   F: 'Elective deferrals under a section 408(k)(6) salary reduction SEP.',
   G: 'Elective deferrals and employer contributions (including nonelective deferrals) to any governmental or nongovernmental section 457(b) deferred compensation plan.',

--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -209,7 +209,7 @@ export const W2Box12CodeDescriptions: { [key in W2Box12Code]: string } = {
   HH: 'Aggregate deferrals under section 83(i) elections as of the close of the calendar year.'
 }
 
-export type W2Box12Info = { [key in W2Box12Code]?: number }
+export type W2Box12Info<A = number> = { [key in W2Box12Code]?: A }
 
 export interface HealthSavingsAccount<DateType = string> {
   label: string

--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -103,7 +103,7 @@ const w2: Arbitrary<types.IncomeW2> = wages.chain((income) =>
   fc
     .tuple(
       maxWords(2),
-      fc.nat({ max: income }),
+      fc.nat({ max: 2 * income }),
       fc.nat({ max: income }),
       fc.nat({ max: income }),
       fc.nat({ max: income }),

--- a/src/forms/Y2020/irsForms/F1040.ts
+++ b/src/forms/Y2020/irsForms/F1040.ts
@@ -491,10 +491,6 @@ export default class F1040 extends Form {
       result.push(F1040Error.filingStatusUndefined)
     }
 
-    if (this.medicareWages() > this.wages()) {
-      result.push(F1040Error.medicareWagesGreaterThanWages)
-    }
-
     const fs = this.info.taxPayer.filingStatus
     const numDependents = this.info.taxPayer.dependents.length
     const hasSpouse = this.info.taxPayer.spouse !== undefined

--- a/src/forms/Y2021/irsForms/F1040.ts
+++ b/src/forms/Y2021/irsForms/F1040.ts
@@ -525,10 +525,6 @@ export default class F1040 extends Form {
       result.push(F1040Error.filingStatusUndefined)
     }
 
-    if (this.medicareWages() > this.wages()) {
-      result.push(F1040Error.medicareWagesGreaterThanWages)
-    }
-
     const fs = this.info.taxPayer.filingStatus
     const numDependents = this.info.taxPayer.dependents.length
     const hasSpouse = this.info.taxPayer.spouse !== undefined

--- a/src/forms/errors.ts
+++ b/src/forms/errors.ts
@@ -1,6 +1,5 @@
 export enum F1040Error {
   unsupportedTaxYear = 'Tax year not supported',
   filingStatusUndefined = 'Select a filing status',
-  medicareWagesGreaterThanWages = 'Medicare wages are not allowed to be greater than wages',
   filingStatusRequirementsNotMet = 'Filing status does not match dependents or spouse requirements'
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
- Bugfix

Fixes #879 
Fixes #880 

Thanks to @dweiss2 and @gnoejuan for their clearly explained bug reports and help figuring out the causes of these issues!

#879: We were not parsing data from string to number and back again for the user form with respect to all the box 12 fields. This caused attempts to save user input strings where numbers were expected.

#880: We were assuming that medicare wages are less than or equal to total wages on the W2. This is a result of incompletely implementing the W2 box 12 data, as box 12 can contain information such as elective 401k contributions. These contributions are not included in Box 1 wages so no income tax is charged on them, but they are included in Box 5 medicare wages because medicare tax may be collected on them. 

This also fixes a no key specified error on the box 12 fields, and a material ui error where the wrong kind of container was used to subdivide the box 12 fields.