### PR TITLE
Fix w2 form to accept any employer name

### DIFF
--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -222,7 +222,7 @@ export default function W2JobInfo(): ReactElement {
         <LabeledInput
           autofocus={true}
           label="Employer name"
-          patternConfig={Patterns.name}
+          required={true}
           name="employer.employerName"
           sizes={{ xs: 12 }}
         />

--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -86,7 +86,7 @@ const address: Arbitrary<types.Address> = fc
   }))
 
 const employer: Arbitrary<types.Employer> = fc
-  .tuple(ein, payerName, address)
+  .tuple(ein, fc.string({ minLength: 1 }), address)
   .map(([EIN, employerName, address]) => ({
     EIN,
     employerName,


### PR DESCRIPTION
Employer names are just informational for the user, and should have no restriction as to format.

Also updates testing so that arbitrary names are generated for employer names.

Fixes #882 

**What kind of change does this PR introduce?** 
- Bugfix

