### PR TITLE
Switch two fields to required only validation

### DIFF
--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -75,7 +75,7 @@ export default function F1098eInfo(): ReactElement {
         <LabeledInput
           autofocus={true}
           label="Enter name of Lender"
-          patternConfig={Patterns.name}
+          required={true}
           name="lender"
         />
         <LabeledInput

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -440,7 +440,7 @@ export default function F1099Info(): ReactElement {
 
         <LabeledInput
           label="Enter name of bank, broker firm, or other payer"
-          patternConfig={Patterns.name}
+          required={true}
           name="payer"
         />
       </Grid>

--- a/src/tests/components/income/F1099Info.test.tsx
+++ b/src/tests/components/income/F1099Info.test.tsx
@@ -67,7 +67,8 @@ const testInformationState: Information = {
   },
   questions: {},
   f1098es: [],
-  stateResidencies: [{ state: 'AL' }]
+  stateResidencies: [{ state: 'AL' }],
+  healthSavingsAccounts: []
 }
 
 describe('F1099Info', () => {
@@ -139,16 +140,11 @@ describe('F1099Info', () => {
       const { labelTextChange, buttonClick } = setup()
 
       buttonClick('Add')
-      labelTextChange(
-        'Enter name of bank, broker firm, or other payer',
-        'payer-name'
-      )
+      labelTextChange('Enter name of bank, broker firm, or other payer', '')
       buttonClick('Save')
 
       await waitFor(() =>
-        expect(
-          screen.getByText('Input should only include letters and spaces')
-        ).toBeInTheDocument()
+        expect(screen.getByText('Input is required')).toBeInTheDocument()
       )
     })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Bugfix

Payer/payee entities can have any characters, user information only anyway.

Fixes #911 

Only remaining fields with alpha-only validation are W-2 occupation, dependent relationship, and city name.

