### PR TITLE
Get ts-jest, for easier debugging setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^ustaxes/(.*)': '<rootDir>/src/$1'
+  },
+  transformIgnorePatterns: ['/node_modules/(?!@tauri-apps)'],
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts']
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "lint-staged": "^12.3.3",
         "prettier": "2.5.1",
         "react-router-last-location": "^2.0.1",
+        "ts-jest": "^26.5.5",
         "ts-node": "^10.5.0",
         "typescript-eslint": "0.0.1-alpha.0"
       },
@@ -5019,6 +5020,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -19401,6 +19414,46 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/ts-jest": {
+      "version": "26.5.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.5.tgz",
+      "integrity": "sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "jest": ">=26 <27",
+        "typescript": ">=3.8 <5.0"
+      }
+    },
+    "node_modules/ts-jest/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ts-json-schema-generator": {
       "version": "0.97.0",
       "license": "MIT",
@@ -24925,6 +24978,15 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -34440,6 +34502,32 @@
     },
     "tryer": {
       "version": "1.0.1"
+    },
+    "ts-jest": {
+      "version": "26.5.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.5.tgz",
+      "integrity": "sha512-7tP4m+silwt1NHqzNRAPjW1BswnAhopTdc2K3HEkRZjF0ZG2F/e/ypVH0xiZIMfItFtD3CX0XFbwPzp9fIEUVg==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
     },
     "ts-json-schema-generator": {
       "version": "0.97.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node ./notice.js && ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && concurrently npm:dev",
     "dev": "craco --openssl-legacy-provider start",
     "build": "ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && craco build",
-    "test": "ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && craco test",
+    "test": "ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && jest",
     "eject": "craco eject",
     "desktop-release": "ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && tauri build",
     "desktop": "node ./notice.js && ts-node ./scripts/env.ts && ts-node ./scripts/setup.ts && tauri dev",
@@ -93,20 +93,13 @@
     "lint-staged": "^12.3.3",
     "prettier": "2.5.1",
     "react-router-last-location": "^2.0.1",
+    "ts-jest": "^26.5.5",
     "ts-node": "^10.5.0",
     "typescript-eslint": "0.0.1-alpha.0"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown .",
     "*.{ts,js,tsx,jsx}": "eslint ./src --cache --fix"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "^ustaxes/(.*)": "<rootDir>/src/$1"
-    },
-    "transformIgnorePatterns": [
-      "/node_modules/(?!@tauri-apps)"
-    ]
   },
   "engines": {
     "yarn": "please-use-npm"

--- a/src/forms/Y2020/tests/f8889.test.ts
+++ b/src/forms/Y2020/tests/f8889.test.ts
@@ -69,6 +69,8 @@ const baseInformation: Information = {
 
 describe('Health Savings Accounts', () => {
   it('shold not need form 8889 if there are no health savings accounts', () => {
+    expect(baseInformation.taxPayer.primaryPerson).not.toBeUndefined()
+    if (baseInformation.taxPayer.primaryPerson === undefined) return
     expect(
       needsF8889(baseInformation, baseInformation.taxPayer.primaryPerson)
     ).toEqual(false)
@@ -88,6 +90,9 @@ describe('Health Savings Accounts', () => {
         qualifiedDistributions: 500
       }
     ]
+
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
 
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.fullYearHsa()).toEqual(true)
@@ -123,6 +128,9 @@ describe('Health Savings Accounts', () => {
       }
     ]
 
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
+
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.fullYearHsa()).toEqual(true)
     expect(f8889.lastMonthCoverage()).toEqual('family')
@@ -146,6 +154,9 @@ describe('Health Savings Accounts', () => {
         qualifiedDistributions: 500
       }
     ]
+
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
 
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.fullYearHsa()).toEqual(false)
@@ -179,6 +190,9 @@ describe('Health Savings Accounts', () => {
         qualifiedDistributions: 500
       }
     ]
+
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
 
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.fullYearHsa()).toEqual(false)
@@ -216,6 +230,9 @@ describe('Health Savings Accounts', () => {
       }
     ]
 
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
+
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.fullYearHsa()).toEqual(false)
     expect(f8889.contributionLimit()).toEqual(
@@ -251,6 +268,9 @@ describe('Health Savings Accounts', () => {
         qualifiedDistributions: 500
       }
     ]
+
+    expect(information.taxPayer.primaryPerson).not.toBeUndefined()
+    if (information.taxPayer.primaryPerson === undefined) return
 
     const f8889 = new F8889(information, information.taxPayer.primaryPerson)
     expect(f8889.splitFamilyContributionLimit()).toEqual(3550)

--- a/src/forms/Y2020/tests/states/il.test.ts
+++ b/src/forms/Y2020/tests/states/il.test.ts
@@ -15,7 +15,7 @@ const withStateReturn = (
   logContext: fc.ContextValue,
   test: (f1040Forms: [F1040, Form[]], stateForms: StateForm[]) => void
 ): void => {
-  const f1040Result = create1040(info)
+  const f1040Result = create1040(info, [])
 
   if (isLeft(f1040Result)) {
     // ignore error infos with no 1040

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,15 +4,19 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/jest-dom'
 
-const localStorageMock = {
+const localStorageMock: Storage = {
+  ...localStorage,
   getItem: jest.fn(),
   setItem: jest.fn(),
   clear: jest.fn()
 }
+
 global.localStorage = localStorageMock
 
 global.console = {
+  ...console,
   log: jest.fn(),
   error: jest.fn(),
 

--- a/src/tests/MultipleYears.test.tsx
+++ b/src/tests/MultipleYears.test.tsx
@@ -2,7 +2,7 @@
 import * as fc from 'fast-check'
 import * as utarbitraries from './arbitraries'
 import { cleanup, waitFor } from '@testing-library/react'
-import { YearsTaxesState } from 'ustaxes/redux'
+import { blankYearTaxesState, YearsTaxesState } from 'ustaxes/redux'
 import { ReactElement } from 'react'
 import TaxPayer from 'ustaxes/components/TaxPayer'
 import { tests as TaxPayerTests } from './components/Taxpayer.test'
@@ -136,7 +136,11 @@ describe('years', () => {
             // Generating states can lead to long runtimes as the generator
             // tries to fiddle with all of state's parameters to induce a failure.
             // We're just testing the year part of the state now.
-            const state = { [startYear]: blankState, activeYear: startYear }
+            const state = {
+              ...blankYearTaxesState,
+              [startYear]: blankState,
+              activeYear: startYear
+            }
             await withForm(state)(async (form): Promise<boolean> => {
               await form.yearStatus.setYear(year)
 
@@ -177,7 +181,11 @@ describe('years', () => {
     ))
 
   it('selecting year should not impact taxpayer form error handling after changing year', async () => {
-    const form = new TestForm({ Y2020: blankState, activeYear: 'Y2020' })
+    const form = new TestForm({
+      ...blankYearTaxesState,
+      Y2020: blankState,
+      activeYear: 'Y2020'
+    })
 
     await TaxPayerTests.incompleteData(form)
 

--- a/src/tests/components/Taxpayer.test.tsx
+++ b/src/tests/components/Taxpayer.test.tsx
@@ -2,7 +2,7 @@ import { waitFor } from '@testing-library/react'
 import { BrowserRouter as Router } from 'react-router-dom'
 import TaxPayer from 'ustaxes/components/TaxPayer'
 import { Information } from 'ustaxes/core/data'
-import { YearsTaxesState } from 'ustaxes/redux'
+import { blankYearTaxesState, YearsTaxesState } from 'ustaxes/redux'
 import { blankState } from 'ustaxes/redux/reducer'
 import { FakePagerProvider, PagerMethods } from '../common/FakePager'
 import TestPage from '../common/Page'
@@ -85,7 +85,12 @@ export const tests = {
 
 describe('Taxpayer', () => {
   const taxpayerComponent = (information: Information = blankState) =>
-    new TaxPayerTestPage({ Y2020: information, activeYear: 'Y2020' })
+    new TaxPayerTestPage({
+      ...blankYearTaxesState,
+      Y2020: information,
+      activeYear: 'Y2020',
+      assets: []
+    })
 
   it('should show errors if incomplete data is entered', async () => {
     const page = taxpayerComponent()


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
- Build-related changes

Just using craco test made it difficult to set up vscode with breakpoints. I'm not exactly sure why, but switching to ts-jest made it easier for me to set up breakpoints.

Using this, I can reliably auto-attach to the node testing process in vscode, and set breakpoints from running tests.

Also, setting up tests this way revealed several type errors in our tests.

<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
