### PR TITLE
Fix default ajv options, eslint react warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   settings: {
     react: {
-      version: 'latest'
+      version: 'detect'
     }
   },
   env: {

--- a/src/core/data/validate.ts
+++ b/src/core/data/validate.ts
@@ -31,7 +31,12 @@ export const checkType = <A>(data: A, validate: ValidateFunction<A>): A => {
   return data
 }
 
-const ajv = new Ajv().addSchema(schema)
+// See this doc for a complete list of available options:
+// ajv.js.org/options.html#option-defaults
+const ajv = new Ajv({
+  allowDate: true,
+  allowUnionTypes: true
+}).addSchema(schema)
 
 // Doing this seems to be necessary so that recursive self
 // links (ref fields) are created properly. Without it we get


### PR DESCRIPTION
**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

At some point after an AJV update, we started seeing many console warnings like this one:

```
    console.warn
      strict mode: use allowUnionTypes to allow union type keyword at "#/definitions/ItemizedDeductions/properties/medicalAndDental" (strictTypes)

      at checkStrictMode (node_modules/ajv/lib/compile/util.ts:212:18)
      at strictTypesError (node_modules/ajv/lib/compile/validate/index.ts:322:18)
      at checkMultipleTypes (node_modules/ajv/lib/compile/validate/index.ts:294:5)
      at checkStrictTypes (node_modules/ajv/lib/compile/validate/index.ts:274:33)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:231:18)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at subSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:147:3)
      at subschemaCode (node_modules/ajv/lib/compile/validate/index.ts:124:7)
```

For example at [this test run](https://github.com/ustaxes/UsTaxes/runs/5351185568?check_suite_focus=true#step:7:19)

There are a lot of ajv options that we could use. [See this doc](https://ajv.js.org/options.html#option-defaults)