### PR TITLE
Revert "Bump @tauri-apps/cli from 1.0.0-rc.4 to 1.0.0-rc.5 (#943)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@material-ui/lab": "^4.0.0-alpha.60",
         "@material-ui/pickers": "^3.3.10",
         "@tauri-apps/api": "^1.0.0-rc.1",
-        "@tauri-apps/cli": "^1.0.0-rc.5",
+        "@tauri-apps/cli": "^1.0.0-rc.4",
         "ajv": "^8.10.0",
         "ajv-formats": "^2.1.1",
         "csv": "^6.0.5",
@@ -3122,9 +3122,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.5.tgz",
-      "integrity": "sha512-Q3D0R5YdZRA5EcL206hwwKCyXpet2mRDcfaRTU/IXwF73bS4AMja+JdAGfO2cyHuSvXd+b//Cgbei2zCG8M6hw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.4.tgz",
+      "integrity": "sha512-VL7/28yzLiMevw4JGsDcEQYCsasNgALUcPKDma6rBv7sPypf4V3fksDCc90xs6usNQeoSfKaiExQWy24shoPDg==",
       "bin": {
         "tauri": "tauri.js"
       },
@@ -3136,20 +3136,20 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.5",
-        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.5",
-        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.5"
+        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.4",
+        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.4",
+        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.4"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.5.tgz",
-      "integrity": "sha512-X+3EIAUGfoL8uE6PBADZC8FcUISe4JPQCxXgaVv6ehoZGoCh/pFJF7AvBGTQxbnvngqM7Xce4Lmh63Io2/5ggw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-TWAQbfABk1qsIAWiEmphKk1D+Qa4fBQE9vk5we5abRsqDCQJKu4c7sVwMYPzsa3fnTQk5mgEiSplevSvbbR3DA==",
       "cpu": [
         "arm64"
       ],
@@ -3162,9 +3162,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.5.tgz",
-      "integrity": "sha512-fEpgOdAvKdq9C5/yip8RnwP1VS+nRrtKdzzplu4jY6njDVH/Vom8mg+EfXkCY5RveCaoskJMFgUvt10IGeZHBA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-7LAMgtZcUxfsCPJynmS9a3mzsT8AFMu5LGIUgPLppiGsaqb5CZUw5WpJQLW16VBPIQ9qR4zxlsCQb7P2WsbXzA==",
       "cpu": [
         "x64"
       ],
@@ -3177,9 +3177,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.5.tgz",
-      "integrity": "sha512-V7sWSBrpLyvkQxpkHIM8JltYqQhiTpThySDjO8POtrTqkRwM5BXORcCYhxTAKCedecfYK/RNUJ6Q0t7+3jS6DQ==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.4.tgz",
+      "integrity": "sha512-Ut3aOMI1dMoPNsvNfJgweqqM5G4G2HBWSdSy5C0hD1GC3Y1xSv1BWORNT/eYNeJF5sCTO+qkslsOVw30xoJ6Fg==",
       "cpu": [
         "arm"
       ],
@@ -3192,9 +3192,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.5.tgz",
-      "integrity": "sha512-HhM+2FInxtUAI/41LF4fDEzmhLQUq6DOoo7fLN94vgWlhsPyWZoDGP9pA043XbO86+4OX5JZUW1SnTVXMwEaMA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-8JEsLGKfu2ffYSMWzMcRHZpzQrMKPmY1HiXi1W8xDOKbwTSaZ4qlP67JAE6UtdvrDJDg/rGGTEs33ZZ0VuCJ9Q==",
       "cpu": [
         "arm64"
       ],
@@ -3207,9 +3207,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.5.tgz",
-      "integrity": "sha512-DhHdKOhf3+peA/sM0c9CpxK89cp8GVwOB5osFW55fxBZbD0mJFeL2SzjkgfGFqFu6Ci/ZiibQGfEp8XTC8OsYA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-UGWY19vCsNpDPQfsfCpeeVVF4mwkbEVUCUdz/PoAtcW07nxa0xI/fNgX6U/LKXepon5z6iUsS5P4AtcLjPw5rw==",
       "cpu": [
         "arm64"
       ],
@@ -3222,9 +3222,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.5.tgz",
-      "integrity": "sha512-pZzsOHRGG/mdcn7fF/yOIOdeVzGxZUtZqvlGSd90ZM9Ps3//uYGCBHoNTbeSwp/V6+D0KVDaSCbm9lYlHoXcdA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-lYs6xMw4Y8FpmRThzsWiXQ7SbR2lyBilC+m9VDQAp1vd1eriF80XtFbfhxKy9Wpm5qzYtcWYoIKWiRDa8LX8DA==",
       "cpu": [
         "x64"
       ],
@@ -3237,9 +3237,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.5.tgz",
-      "integrity": "sha512-COwWCbOhEjBlzGRGTa0ESO4/AiC0cBZ2UEPExRn++S+kWSPJ2vsyMdCLu3hiMy1ABSIRcQ4Vc68M1iVkLhOHHw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-DL4KT4dj2k+y1C3NTY5Fr85/WeYYlpcZZsLzF451wevFunNfGw5kic3tSaaJPtkjgK21t1Bw/hd3XtP6QtFuiA==",
       "cpu": [
         "x64"
       ],
@@ -3252,9 +3252,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.5.tgz",
-      "integrity": "sha512-zzizUmPWvnWjj+IUCk36kVjS9j1Bg5JmnwOW5QdX26+a64q5vocmVimCgrfZ5STw3sDFXE++S55ghpzhhH5o+g==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.4.tgz",
+      "integrity": "sha512-GFhupERiJX48k5hiepNfOm2FCcRTmNQ8m+XfW4slJ61v71wth06kFnFXrbLxTBd8wy77AD7yEGTahjGvR+9CAQ==",
       "cpu": [
         "x64"
       ],
@@ -23852,66 +23852,66 @@
       }
     },
     "@tauri-apps/cli": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.5.tgz",
-      "integrity": "sha512-Q3D0R5YdZRA5EcL206hwwKCyXpet2mRDcfaRTU/IXwF73bS4AMja+JdAGfO2cyHuSvXd+b//Cgbei2zCG8M6hw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.4.tgz",
+      "integrity": "sha512-VL7/28yzLiMevw4JGsDcEQYCsasNgALUcPKDma6rBv7sPypf4V3fksDCc90xs6usNQeoSfKaiExQWy24shoPDg==",
       "requires": {
-        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.5",
-        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.5",
-        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.5",
-        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.5"
+        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.4",
+        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.4",
+        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.4",
+        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.4"
       }
     },
     "@tauri-apps/cli-darwin-arm64": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.5.tgz",
-      "integrity": "sha512-X+3EIAUGfoL8uE6PBADZC8FcUISe4JPQCxXgaVv6ehoZGoCh/pFJF7AvBGTQxbnvngqM7Xce4Lmh63Io2/5ggw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-TWAQbfABk1qsIAWiEmphKk1D+Qa4fBQE9vk5we5abRsqDCQJKu4c7sVwMYPzsa3fnTQk5mgEiSplevSvbbR3DA==",
       "optional": true
     },
     "@tauri-apps/cli-darwin-x64": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.5.tgz",
-      "integrity": "sha512-fEpgOdAvKdq9C5/yip8RnwP1VS+nRrtKdzzplu4jY6njDVH/Vom8mg+EfXkCY5RveCaoskJMFgUvt10IGeZHBA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.4.tgz",
+      "integrity": "sha512-7LAMgtZcUxfsCPJynmS9a3mzsT8AFMu5LGIUgPLppiGsaqb5CZUw5WpJQLW16VBPIQ9qR4zxlsCQb7P2WsbXzA==",
       "optional": true
     },
     "@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.5.tgz",
-      "integrity": "sha512-V7sWSBrpLyvkQxpkHIM8JltYqQhiTpThySDjO8POtrTqkRwM5BXORcCYhxTAKCedecfYK/RNUJ6Q0t7+3jS6DQ==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.4.tgz",
+      "integrity": "sha512-Ut3aOMI1dMoPNsvNfJgweqqM5G4G2HBWSdSy5C0hD1GC3Y1xSv1BWORNT/eYNeJF5sCTO+qkslsOVw30xoJ6Fg==",
       "optional": true
     },
     "@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.5.tgz",
-      "integrity": "sha512-HhM+2FInxtUAI/41LF4fDEzmhLQUq6DOoo7fLN94vgWlhsPyWZoDGP9pA043XbO86+4OX5JZUW1SnTVXMwEaMA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-8JEsLGKfu2ffYSMWzMcRHZpzQrMKPmY1HiXi1W8xDOKbwTSaZ4qlP67JAE6UtdvrDJDg/rGGTEs33ZZ0VuCJ9Q==",
       "optional": true
     },
     "@tauri-apps/cli-linux-arm64-musl": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.5.tgz",
-      "integrity": "sha512-DhHdKOhf3+peA/sM0c9CpxK89cp8GVwOB5osFW55fxBZbD0mJFeL2SzjkgfGFqFu6Ci/ZiibQGfEp8XTC8OsYA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-UGWY19vCsNpDPQfsfCpeeVVF4mwkbEVUCUdz/PoAtcW07nxa0xI/fNgX6U/LKXepon5z6iUsS5P4AtcLjPw5rw==",
       "optional": true
     },
     "@tauri-apps/cli-linux-x64-gnu": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.5.tgz",
-      "integrity": "sha512-pZzsOHRGG/mdcn7fF/yOIOdeVzGxZUtZqvlGSd90ZM9Ps3//uYGCBHoNTbeSwp/V6+D0KVDaSCbm9lYlHoXcdA==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.4.tgz",
+      "integrity": "sha512-lYs6xMw4Y8FpmRThzsWiXQ7SbR2lyBilC+m9VDQAp1vd1eriF80XtFbfhxKy9Wpm5qzYtcWYoIKWiRDa8LX8DA==",
       "optional": true
     },
     "@tauri-apps/cli-linux-x64-musl": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.5.tgz",
-      "integrity": "sha512-COwWCbOhEjBlzGRGTa0ESO4/AiC0cBZ2UEPExRn++S+kWSPJ2vsyMdCLu3hiMy1ABSIRcQ4Vc68M1iVkLhOHHw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.4.tgz",
+      "integrity": "sha512-DL4KT4dj2k+y1C3NTY5Fr85/WeYYlpcZZsLzF451wevFunNfGw5kic3tSaaJPtkjgK21t1Bw/hd3XtP6QtFuiA==",
       "optional": true
     },
     "@tauri-apps/cli-win32-x64-msvc": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.5.tgz",
-      "integrity": "sha512-zzizUmPWvnWjj+IUCk36kVjS9j1Bg5JmnwOW5QdX26+a64q5vocmVimCgrfZ5STw3sDFXE++S55ghpzhhH5o+g==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.4.tgz",
+      "integrity": "sha512-GFhupERiJX48k5hiepNfOm2FCcRTmNQ8m+XfW4slJ61v71wth06kFnFXrbLxTBd8wy77AD7yEGTahjGvR+9CAQ==",
       "optional": true
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/pickers": "^3.3.10",
     "@tauri-apps/api": "^1.0.0-rc.1",
-    "@tauri-apps/cli": "^1.0.0-rc.5",
+    "@tauri-apps/cli": "^1.0.0-rc.4",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
     "csv": "^6.0.5",


### PR DESCRIPTION
This reverts commit d6b99144764081468e284553de105558bca69fc0.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix fixes Error: Cannot find module '@tauri-apps/cli-linux-x64-gnu' causing release action to fail
<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
