### PR TITLE
make load able to pick json in macos chrome

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -25,6 +25,7 @@ const UserSettings = (): ReactElement => {
       </p>
       <Load<USTSerializedState>
         startIcon={done ? <Check /> : undefined}
+        accept="*.json"
         handleData={(state) => {
           if (!done) {
             dispatch(fsRecover(state))

--- a/src/redux/fs/Load.tsx
+++ b/src/redux/fs/Load.tsx
@@ -35,7 +35,7 @@ export const LoadRaw = (
 }
 
 const Load = <S,>(
-  props: PropsWithChildren<LoadProps<S> & ButtonProps>
+  props: PropsWithChildren<LoadProps<S> & ButtonProps & Accept>
 ): ReactElement => {
   const { children, handleData, ...rest } = props
 


### PR DESCRIPTION
was having a hard time loading my saved json data on macos chrome