### PR TITLE
Allow Schedule B to be attached multiple times

### DIFF
--- a/src/forms/Y2020/irsForms/F1040.ts
+++ b/src/forms/Y2020/irsForms/F1040.ts
@@ -114,6 +114,7 @@ export default class F1040 extends Form {
       this,
       this.scheduleA,
       this.scheduleB,
+      ...(this.scheduleB?.copies ?? []),
       this.scheduleD,
       this.scheduleE,
       this.scheduleR,
@@ -149,10 +150,13 @@ export default class F1040 extends Form {
 
   makeSchedules = (): void => {
     const f1099bs = this.info.f1099Bs()
-    const f1099ints = this.info.f1099Ints()
+
     const f1099ssas = this.info.f1099ssas()
-    if (f1099ints.length > 0) {
-      this.scheduleB = new ScheduleB(this.info)
+
+    const scheduleB = new ScheduleB(this.info)
+
+    if (scheduleB.formRequired()) {
+      this.scheduleB = scheduleB
     }
 
     if (this.assets.length > 0) {
@@ -340,9 +344,9 @@ export default class F1040 extends Form {
 
   l1 = (): number => this.wages()
   l2a = (): number | undefined => this.scheduleB?.l3()
-  l2b = (): number | undefined => this.scheduleB?.l4()
+  l2b = (): number | undefined => this.scheduleB?.to1040l2b()
   l3a = (): number | undefined => this.totalQualifiedDividends()
-  l3b = (): number | undefined => this.scheduleB?.l6()
+  l3b = (): number | undefined => this.scheduleB?.to1040l3b()
   // This is the value of box 1 in 1099-R forms coming from IRAs
   l4a = (): number | undefined => this.totalGrossDistributionsFromIra()
   // This should be the value of box 2a in 1099-R coming from IRAs

--- a/src/forms/Y2020/irsForms/ScheduleB.ts
+++ b/src/forms/Y2020/irsForms/ScheduleB.ts
@@ -16,10 +16,34 @@ export default class ScheduleB extends Form {
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16
 
-  constructor(info: Information) {
+  index = 0
+  copies: ScheduleB[] = []
+
+  constructor(info: Information, index = 0) {
     super()
     this.state = new InformationMethods(info)
+
+    this.index = index
+
+    if (index === 0) {
+      const numInterestPayers = this.l1Fields().length
+      const numDivPayers = this.l5Fields().length
+
+      const extraCopiesNeeded = Math.floor(
+        Math.max(
+          numInterestPayers / this.interestPayersLimit,
+          numDivPayers / this.dividendPayersLimit
+        )
+      )
+
+      this.copies = Array.from(Array(extraCopiesNeeded)).map(
+        (_, i) => new ScheduleB(info, i + 1)
+      )
+    }
   }
+
+  formRequired = (): boolean =>
+    this.l1Fields().length > 0 || this.l5Fields().length > 0
 
   l1Fields = (): PayerAmount[] =>
     this.state.f1099Ints().map((v) => ({
@@ -28,7 +52,11 @@ export default class ScheduleB extends Form {
     }))
 
   l1 = (): Array<string | undefined> => {
-    const payerValues = this.l1Fields()
+    const payerValues = this.l1Fields().slice(
+      this.index * this.interestPayersLimit,
+      (this.index + 1) * this.interestPayersLimit
+    )
+
     const rightPad = 2 * (this.interestPayersLimit - payerValues.length)
     // ensure we return an array of length interestPayersLimit * 2.
     return payerValues
@@ -38,9 +66,16 @@ export default class ScheduleB extends Form {
 
   l2 = (): number => sumFields(this.state.f1099Ints().map((f) => f.form.income))
 
+  // TODO: Interest from tax exempt savings bonds
   l3 = (): number | undefined => undefined
 
-  l4 = (): number | undefined => this.l2() - (this.l3() ?? 0)
+  l4 = (): number => this.l2() - (this.l3() ?? 0)
+
+  /**
+   * Total interest on all schedule Bs.
+   */
+  to1040l2b = (): number =>
+    [this, ...this.copies].reduce((acc, f) => acc + f.l4(), 0)
 
   l5Fields = (): PayerAmount[] =>
     this.state.f1099Divs().map((v) => ({
@@ -49,18 +84,28 @@ export default class ScheduleB extends Form {
     }))
 
   l5 = (): Array<string | undefined | number> => {
-    const payerValues = this.l5Fields()
+    const payerValues = this.l5Fields().slice(
+      this.index * this.dividendPayersLimit,
+      (this.index + 1) * this.dividendPayersLimit
+    )
+
     const rightPad = 2 * (this.dividendPayersLimit - payerValues.length)
     return payerValues
       .flatMap(({ payer, amount }) => [payer, amount])
       .concat(Array(rightPad).fill(undefined))
   }
 
-  l6 = (): number | undefined =>
-    sumFields(this.l5Fields().map(({ amount }) => amount))
+  l6 = (): number => sumFields(this.l5Fields().map(({ amount }) => amount))
+
+  /**
+   * Total dividends on all schedule Bs.
+   */
+  to1040l3b = (): number =>
+    [this, ...this.copies].reduce((acc, f) => acc + f.l6(), 0)
 
   foreignAccount = (): boolean =>
     this.state.questions.FOREIGN_ACCOUNT_EXISTS ?? false
+
   fincenForm = (): boolean => this.state.questions.FINCEN_114 ?? false
   fincenCountry = (): string | undefined =>
     this.state.questions.FINCEN_114_ACCOUNT_COUNTRY

--- a/src/forms/Y2021/irsForms/F1040.ts
+++ b/src/forms/Y2021/irsForms/F1040.ts
@@ -128,6 +128,7 @@ export default class F1040 extends Form {
       this,
       this.scheduleA,
       this.scheduleB,
+      ...(this.scheduleB?.copies ?? []),
       this.scheduleD,
       this.scheduleE,
       this.scheduleSE,
@@ -165,11 +166,14 @@ export default class F1040 extends Form {
 
   makeSchedules = (): void => {
     const f1099bs = this.info.f1099Bs()
-    const f1099ints = this.info.f1099Ints()
     const f1099ssas = this.info.f1099ssas()
-    if (f1099ints.length > 0) {
-      this.scheduleB = new ScheduleB(this.info)
+
+    const scheduleB = new ScheduleB(this.info)
+
+    if (scheduleB.formRequired()) {
+      this.scheduleB = scheduleB
     }
+
     if (this.info.itemizedDeductions) {
       const scheduleA = new ScheduleA(this)
       const standardDeduction = this.standardDeduction()
@@ -409,9 +413,9 @@ export default class F1040 extends Form {
 
   l1 = (): number => this.wages()
   l2a = (): number | undefined => this.scheduleB?.l3()
-  l2b = (): number | undefined => this.scheduleB?.l4()
+  l2b = (): number | undefined => this.scheduleB?.to1040l2b()
   l3a = (): number | undefined => this.totalQualifiedDividends()
-  l3b = (): number | undefined => this.scheduleB?.l6()
+  l3b = (): number | undefined => this.scheduleB?.to1040l3b()
   // This is the value of box 1 in 1099-R forms coming from IRAs
   l4a = (): number | undefined => this.totalGrossDistributionsFromIra()
   // This should be the value of box 2a in 1099-R coming from IRAs

--- a/src/forms/Y2021/irsForms/ScheduleB.ts
+++ b/src/forms/Y2021/irsForms/ScheduleB.ts
@@ -16,10 +16,33 @@ export default class ScheduleB extends Form {
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16
 
-  constructor(info: Information) {
+  index = 0
+  copies: ScheduleB[] = []
+
+  constructor(info: Information, index = 0) {
     super()
     this.state = new InformationMethods(info)
+    this.index = index
+
+    if (index === 0) {
+      const numInterestPayers = this.l1Fields().length
+      const numDivPayers = this.l5Fields().length
+
+      const extraCopiesNeeded = Math.floor(
+        Math.max(
+          numInterestPayers / this.interestPayersLimit,
+          numDivPayers / this.dividendPayersLimit
+        )
+      )
+
+      this.copies = Array.from(Array(extraCopiesNeeded)).map(
+        (_, i) => new ScheduleB(info, i + 1)
+      )
+    }
   }
+
+  formRequired = (): boolean =>
+    this.l1Fields().length > 0 || this.l5Fields().length > 0
 
   l1Fields = (): PayerAmount[] =>
     this.state
@@ -36,9 +59,13 @@ export default class ScheduleB extends Form {
       )
 
   l1 = (): Array<string | undefined> => {
-    const payerValues = this.l1Fields()
+    const payerValues = this.l1Fields().slice(
+      this.index * this.interestPayersLimit,
+      (this.index + 1) * this.interestPayersLimit
+    )
     const rightPad = 2 * (this.interestPayersLimit - payerValues.length)
     // ensure we return an array of length interestPayersLimit * 2.
+    // This form may have multiple copies, only display the copies for this form
     return payerValues
       .flatMap(({ payer, amount }) => [payer, amount?.toString()])
       .concat(Array(rightPad).fill(undefined))
@@ -46,9 +73,16 @@ export default class ScheduleB extends Form {
 
   l2 = (): number => sumFields(this.state.f1099Ints().map((f) => f.form.income))
 
+  // TODO: Interest from tax exempt savings bonds
   l3 = (): number | undefined => undefined
 
-  l4 = (): number | undefined => this.l2() - (this.l3() ?? 0)
+  l4 = (): number => this.l2() - (this.l3() ?? 0)
+
+  /**
+   * Total interest on all schedule Bs.
+   */
+  to1040l2b = (): number =>
+    [this, ...this.copies].reduce((acc, f) => acc + f.l4(), 0)
 
   l5Fields = (): PayerAmount[] =>
     this.state.f1099Divs().map((v) => ({
@@ -57,15 +91,24 @@ export default class ScheduleB extends Form {
     }))
 
   l5 = (): Array<string | undefined | number> => {
-    const payerValues = this.l5Fields()
+    const payerValues = this.l5Fields().slice(
+      this.index * this.dividendPayersLimit,
+      (this.index + 1) * this.dividendPayersLimit
+    )
+
     const rightPad = 2 * (this.dividendPayersLimit - payerValues.length)
     return payerValues
       .flatMap(({ payer, amount }) => [payer, amount])
       .concat(Array(rightPad).fill(undefined))
   }
 
-  l6 = (): number | undefined =>
-    sumFields(this.l5Fields().map(({ amount }) => amount))
+  l6 = (): number => sumFields(this.l5Fields().map(({ amount }) => amount))
+
+  /**
+   * Total dividends on all schedule Bs.
+   */
+  to1040l3b = (): number =>
+    [this, ...this.copies].reduce((acc, f) => acc + f.l6(), 0)
 
   foreignAccount = (): boolean =>
     this.state.questions.FOREIGN_ACCOUNT_EXISTS ?? false


### PR DESCRIPTION
**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

We've been seeing errors on most PRs now, due to generated taxpayer information containing more sources of interest received than fit on Schedule B. 

Solving this by attaching schedule B numerous times.