### PR TITLE
Update threshholds for excess social security tax

### DIFF
--- a/src/forms/Y2021/data/federal.ts
+++ b/src/forms/Y2021/data/federal.ts
@@ -130,8 +130,8 @@ const federalBrackets: FederalBrackets = {
 }
 
 export const fica = {
-  maxSSTax: 8537.4,
-  maxIncomeSSTaxApplies: 137700,
+  maxSSTax: 8853.6,
+  maxIncomeSSTaxApplies: 142800,
 
   regularMedicareTaxRate: 1.45 / 100,
   additionalMedicareTaxRate: 0.9 / 100,


### PR DESCRIPTION
The 2021 form was still using the 2020 numbers causing the tax
credit not to be applied

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?**
- Bugfix


<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
