### PR TITLE
Improve startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# [ustaxes.org](//ustaxes.org) [![Netlify Status][netlify-badge]][netlify-url] [![Github Latest Release][release-badge]][github-release] [![discord-badge]][discord-url]
+<div align="center">
+<h1><a href="//ustaxes.org">USTaxes</a></h1>
+
+[![Netlify Status][netlify-badge]][netlify-url] [![Github Latest Release][release-badge]][github-release] [![discord-badge]][discord-url]
+
+</div>
 
 ## What is UsTaxes?
 
-UsTaxes is a free open source tax filing application that can be used to file the Federal 1040 form. It is available in both [web](https://ustaxes.org/) and [desktop](#desktop-application) versions. It is provided free of charge and requires no sharing of personal data.
+UsTaxes is a free, open-source tax filing application that can be used to file the Federal 1040 form. It is available in both [web](https://ustaxes.org/) and [desktop][desktop-releases] versions. It is provided free of charge and requires no sharing of personal data.
+
+**Interested in contributing? [Get Started](#user-content-get-started)**
 
 ## Supported Income data
 
@@ -60,7 +67,7 @@ Users who only have wage income and live in the states below should be able to f
 
 ## Note on using this project
 
-- This project is built by a growing community. If you notice an error in the outputted PDF or any other error, please submit an issue on the Github issues tab. We appreciate your feedback!
+This project is built by a growing community. If you notice an error in the outputted PDF or any other error, please submit an issue on the Github issues tab. We appreciate your feedback!
 
 ## User Data
 
@@ -76,13 +83,41 @@ To ensure the project is fun for every contributor, please review:
 - [Contributing guide](docs/CONTRIBUTING.md)
 - [Project Architecture](docs/ARCHITECTURE.md)
 
-## Running
+## Get Started
 
 This application can be run as either a web application or a standalone desktop application.
 
 ### Web application
 
-To run, `npm install` then `npm run start`
+This project runs on Node 16. To ensure you're on the proper version, we recommend [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+With `nvm` installed, you may select a version 16 node using:
+
+```
+nvm install 16
+nvm use 16
+```
+
+To run,
+
+```
+npm ci          # install package dependencies
+npm run start   # run app
+```
+
+Note: To avoid having to set your node versions, we suggest using a tool like [direnv](https://direnv.net). For example, with the following configuration:
+
+```
+export NVM_DIR="$HOME/.nvm"
+
+. "$NVM_DIR/nvm.sh"  # This loads nvm
+#. "$NVM_DIR/bash_completion"  # Optional, nvm bash completion
+
+nvm install 16
+nvm use 16
+```
+
+your environment will be set up every time you enter the project directory.
 
 If preferred, a Docker alternative is available:
 
@@ -91,21 +126,28 @@ docker-compose build
 docker-compose up
 ```
 
-Then, open a browser to `http://localhost:3000`.
+Open a browser to `http://localhost:3000`.
 
 To stop and remove running containers, run `docker-compose down`.
 
 ### Desktop application
 
-To run, `npm run desktop`. This requires [rust and cargo][cargo-docs] to be available on PATH. To avoid a browser window being spawned in addition to the desktop window, just set the BROWSER environment variable as in: `BROWSER=none npm run desktop`.
+The desktop application is built with [Tauri][tauri-root]. In addition to the above steps, please [follow this reference for setting up your environment for Tauri](https://tauri.studio/en/docs/getting-started/intro/#setting-up-your-environment).
 
-To release, run `npm run desktop-release`. This will produce executables for your current environment.
+Once your environment is set up for tauri, run, `npm run desktop`. To avoid a browser window being spawned in addition to the desktop window, just set the BROWSER environment variable as in: `BROWSER=none npm run desktop`.
+
+To build executables, run `npm run desktop-release`.
+
+## Getting help
+
+Please reach out to us on our [discord][discord-url] if you run into any problems, or [file an issue][github-issues]. Thank you for your support!
 
 [netlify-badge]: https://api.netlify.com/api/v1/badges/41efe456-a85d-4fed-9fcf-55fe4d5aa7fa/deploy-status
 [netlify-url]: https://app.netlify.com/sites/peaceful-joliot-d51349/deploys
-[webview2]: https://developer.microsoft.com/en-us/microsoft-edge/webview2/
 [cargo-docs]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [discord-badge]: https://img.shields.io/discord/812156892343828500?logo=Discord
 [discord-url]: https://discord.gg/dAaz472mPz
 [github-release]: https://github.com/ustaxes/UsTaxes/releases/latest
 [release-badge]: https://badgen.net/github/release/ustaxes/ustaxes
+[desktop-releases]: https://github.com/ustaxes/UsTaxes/releases/
+[github-issues]: https://github.com/ustaxes/ustaxes/issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,3 @@ services:
       - '3000:3000'
     volumes:
       - ./:/app
-      - /app/node_modules

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,33 +2,6 @@
 
 Thank you for your interest in this project. The below should summarize the general design framework used in this project, and hopefully guide you in understanding the code and getting ready to contribute to the project. If anything at all is unclear please join the discord linked on the readme and feel free to ask any questions you might have.
 
-## Stack and developer requirements
-
-This project uses TypeScript and is built with [NPM 8][npm-install].
-
-## Desktop application requirements
-
-The desktop application is built with [Tauri][tauri-root], see [this reference for setting up your environment for Tauri](https://tauri.studio/en/docs/getting-started/intro/#setting-up-your-environment). While this project does not have any significant rust code yet, this may be built out in the future. Running the application as a desktop app requires [Rust][rust-root] installed.
-
-Specific architecture setup requirements we have run into are:
-
-### Windows
-
-For Windows users, please install [Microsoft Edge WebView2][webview2] before running the desktop application.
-
-### Linux
-
-Running the desktop version requires at least the following to be installed:
-
-```
-libssl-dev
-libgtk3-dev
-libgtk-3-dev
-libsoup2.4-dev
-webkit2gtk-driver
-libwebkit2gtk-4.0-dev
-```
-
 ## Project design
 
 There are four main concerns separated in this project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ustaxes",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@date-io/date-fns": "^1.3.13",
         "@material-ui/core": "^4.12.3",


### PR DESCRIPTION
Addressing feedback from #1032

* Delegates all desktop setup to tauri's official docs
* Specifies to develop locally on node 16 only, and gives some guidance on setting that up
* Moves setup instructions out of the Architecture doc
* Fix docker-compose configuration, which could cause an error if the user doesn't already have a node_modules folder prior to running.


**What kind of change does this PR introduce?** (delete not applicable)
- Docs
