### PR TITLE
Fix for excess FICA taxes (Schedule 3 line 11)

### DIFF
--- a/src/forms/Y2020/irsForms/Schedule3.ts
+++ b/src/forms/Y2020/irsForms/Schedule3.ts
@@ -1,4 +1,4 @@
-import { Information, IncomeW2 } from 'ustaxes/core/data'
+import { Information, IncomeW2, PersonRole } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
@@ -6,21 +6,39 @@ import { fica } from '../data/federal'
 import F1040 from './F1040'
 
 export const claimableExcessSSTaxWithholding = (w2s: IncomeW2[]): number => {
-  // 1040 instructions:
-  // If you had more than one employer and total wages of more than $137,700, too
-  // much SS or RRTA tax may have been withheld. You can take a credit for the amount
-  // withtheld in excess of $8,537.40.
-  // If any one employer withheld more than $8,537.40, you can't claim the excess on
-  // your return.
+  /* Excess FICA taxes are calculated per person. If an individual person
+     has greater than the applicable amount then they are entitled to a refund
+     of that amount
+   */
+  let claimableExcessFica = 0
+  const primaryFica = w2s
+    .filter((w2) => w2.personRole == PersonRole.PRIMARY)
+    .map((w2) => w2.ssWithholding)
+    .reduce((l, r) => l + r, 0)
+  const spouseFica = w2s
+    .filter((w2) => w2.personRole == PersonRole.SPOUSE)
+    .map((w2) => w2.ssWithholding)
+    .reduce((l, r) => l + r, 0)
+
   if (
-    w2s.length > 1 &&
-    w2s.reduce((sum, w2) => sum + w2.income, 0) > fica.maxIncomeSSTaxApplies &&
-    w2s.every((w2) => w2.ssWithholding <= fica.maxSSTax)
+    primaryFica > fica.maxSSTax &&
+    w2s
+      .filter((w2) => w2.personRole == PersonRole.PRIMARY)
+      .every((w2) => w2.ssWithholding <= fica.maxSSTax)
   ) {
-    return w2s.reduce((sum, w2) => sum + w2.ssWithholding, 0) - fica.maxSSTax
-  } else {
-    return 0 // Cannot claim credit for excess SS tax
+    claimableExcessFica += primaryFica - fica.maxSSTax
   }
+
+  if (
+    spouseFica > fica.maxSSTax &&
+    w2s
+      .filter((w2) => w2.personRole == PersonRole.SPOUSE)
+      .every((w2) => w2.ssWithholding <= fica.maxSSTax)
+  ) {
+    claimableExcessFica += spouseFica - fica.maxSSTax
+  }
+
+  return claimableExcessFica
 }
 
 export default class Schedule3 extends Form {

--- a/src/forms/Y2021/irsForms/Schedule3.ts
+++ b/src/forms/Y2021/irsForms/Schedule3.ts
@@ -1,4 +1,4 @@
-import { Information, IncomeW2 } from 'ustaxes/core/data'
+import { Information, IncomeW2, PersonRole } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
@@ -6,25 +6,39 @@ import { fica } from '../data/federal'
 import F1040 from './F1040'
 
 export const claimableExcessSSTaxWithholding = (w2s: IncomeW2[]): number => {
-  // 1040 instructions:
-  // If you had more than one employer and total wages of more than $137,700, too
-  // much SS or RRTA tax may have been withheld. You can take a credit for the amount
-  // withtheld in excess of $8,537.40.
-  // If any one employer withheld more than $8,537.40, you can't claim the excess on
-  // your return.
+  /* Excess FICA taxes are calculated per person. If an individual person
+     has greater than the applicable amount then they are entitled to a refund
+     of that amount
+   */
+  let claimableExcessFica = 0
+  const primaryFica = w2s
+    .filter((w2) => w2.personRole == PersonRole.PRIMARY)
+    .map((w2) => w2.ssWithholding)
+    .reduce((l, r) => l + r, 0)
+  const spouseFica = w2s
+    .filter((w2) => w2.personRole == PersonRole.SPOUSE)
+    .map((w2) => w2.ssWithholding)
+    .reduce((l, r) => l + r, 0)
+
   if (
-    w2s.length > 1 &&
-    w2s.map((w2) => w2.income).reduce((l, r) => l + r, 0) >
-      fica.maxIncomeSSTaxApplies &&
-    w2s.every((w2) => w2.ssWithholding <= fica.maxSSTax)
+    primaryFica > fica.maxSSTax &&
+    w2s
+      .filter((w2) => w2.personRole == PersonRole.PRIMARY)
+      .every((w2) => w2.ssWithholding <= fica.maxSSTax)
   ) {
-    return (
-      w2s.map((w2) => w2.ssWithholding).reduce((l, r) => l + r, 0) -
-      fica.maxSSTax
-    )
-  } else {
-    return 0 // Cannot claim credit for excess SS tax
+    claimableExcessFica += primaryFica - fica.maxSSTax
   }
+
+  if (
+    spouseFica > fica.maxSSTax &&
+    w2s
+      .filter((w2) => w2.personRole == PersonRole.SPOUSE)
+      .every((w2) => w2.ssWithholding <= fica.maxSSTax)
+  ) {
+    claimableExcessFica += spouseFica - fica.maxSSTax
+  }
+
+  return claimableExcessFica
 }
 
 export default class Schedule3 extends Form {


### PR DESCRIPTION
FICA taxes are calculated per person which means that any excess amount that can be claimed should be calculated for the primary and the spouse separately. The previous logic did not differentiate the w2s between individuals so the excess amount was calculated to be too high.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** 
- Bugfix


<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
