### PR TITLE
Fix two field issues with Schedule 1

### DIFF
--- a/src/forms/Y2021/irsForms/Schedule1.ts
+++ b/src/forms/Y2021/irsForms/Schedule1.ts
@@ -52,8 +52,9 @@ export default class Schedule1 extends Form {
   l8q = (): number | undefined => undefined
   l8z = (): number => {
     if (
-      this.f1040.f8889?.l20() !== undefined ||
-      this.f1040.f8889Spouse?.l20() != undefined
+      (this.f1040.f8889?.l20() !== undefined && this.f1040.f8889?.l20() > 0) ||
+      (this.f1040.f8889Spouse?.l20() !== undefined &&
+        this.f1040.f8889Spouse?.l20() > 0)
     ) {
       this.otherIncomeStrings.add('HSA')
     }
@@ -126,6 +127,7 @@ export default class Schedule1 extends Form {
   l24j = (): number | undefined => undefined
   l24k = (): number | undefined => undefined
   l24zDesc = (): string | undefined => undefined
+  l24zDesc2 = (): string | undefined => undefined
   l24z = (): number | undefined => undefined
 
   l25 = (): number =>
@@ -225,6 +227,7 @@ export default class Schedule1 extends Form {
       this.l24j(),
       this.l24k(),
       this.l24zDesc(),
+      this.l24zDesc2(),
       this.l24z(),
       this.l25(),
       this.l26()


### PR DESCRIPTION
- Fixes #1047
- fix issue where 'HSA' would be added to line 8z even if there
  was no additional income. Caused because form 8889 line 20 always
  returns a number but was only checking for undefined. It will
  be undefined only if the form itself is not attached.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** 
- Bugfix


<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
