### PR TITLE
Age and blindness

### DIFF
--- a/src/components/TaxPayer/PersonFields.tsx
+++ b/src/components/TaxPayer/PersonFields.tsx
@@ -7,7 +7,12 @@ import {
   ListItemSecondaryAction
 } from '@material-ui/core'
 import { useDispatch, useSelector, TaxesState } from 'ustaxes/redux'
-import { formatSSID, LabeledInput } from 'ustaxes/components/input'
+import {
+  formatSSID,
+  LabeledInput,
+  LabeledCheckbox,
+  DatePicker
+} from 'ustaxes/components/input'
 import { Patterns } from 'ustaxes/components/Patterns'
 import { removeDependent } from 'ustaxes/redux/actions'
 import { Person } from 'ustaxes/core/data'
@@ -39,6 +44,14 @@ export const PersonFields = ({
         label={labels.ssn}
         name="ssid"
         patternConfig={Patterns.ssn}
+      />
+      <LabeledCheckbox label="Is this person blind?" name="isBlind" />
+      <DatePicker
+        name="dateOfBirth"
+        label="Date of Birth"
+        sizes={{ xs: 12, lg: 6 }}
+        minDate={new Date(1900, 0, 1)}
+        maxDate={new Date()}
       />
       {children}
     </>

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -51,7 +51,6 @@ const blankUserPersonForm: UserPersonForm = {
 
 interface UserDependentForm extends UserPersonForm {
   relationship: string
-  birthYear: string
   isStudent: boolean
   numberOfMonths: string
 }
@@ -59,19 +58,17 @@ interface UserDependentForm extends UserPersonForm {
 const blankUserDependentForm: UserDependentForm = {
   ...blankUserPersonForm,
   relationship: '',
-  birthYear: '',
   isStudent: false,
   numberOfMonths: ''
 }
 
 const toDependent = (formData: UserDependentForm): Dependent => {
-  const { birthYear, isStudent, numberOfMonths, ...rest } = formData
+  const { isStudent, numberOfMonths, ...rest } = formData
 
   return {
     ...rest,
     role: PersonRole.DEPENDENT,
     qualifyingInfo: {
-      birthYear: parseInt(birthYear),
       numberOfMonths: parseInt(numberOfMonths),
       isStudent
     },
@@ -84,7 +81,6 @@ const toDependentForm = (dependent: Dependent): UserDependentForm => {
 
   return {
     ...rest,
-    birthYear: qualifyingInfo?.birthYear.toString() ?? '',
     numberOfMonths: qualifyingInfo?.numberOfMonths.toString() ?? '',
     isStudent: qualifyingInfo?.isStudent ?? false,
     dateOfBirth: new Date(rest.dateOfBirth)
@@ -148,11 +144,6 @@ export const AddDependentForm = (): ReactElement => {
           label="Relationship to Taxpayer"
           name="relationship"
           patternConfig={Patterns.name}
-        />
-        <LabeledInput
-          label="Birth Year"
-          patternConfig={Patterns.year}
-          name="birthYear"
         />
         <LabeledInput
           label="How many months did you live together this year?"

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -37,12 +37,16 @@ interface UserPersonForm {
   firstName: string
   lastName: string
   ssid: string
+  isBlind: boolean
+  dateOfBirth: Date
 }
 
 const blankUserPersonForm: UserPersonForm = {
   firstName: '',
   lastName: '',
-  ssid: ''
+  ssid: '',
+  isBlind: false,
+  dateOfBirth: new Date()
 }
 
 interface UserDependentForm extends UserPersonForm {
@@ -70,7 +74,8 @@ const toDependent = (formData: UserDependentForm): Dependent => {
       birthYear: parseInt(birthYear),
       numberOfMonths: parseInt(numberOfMonths),
       isStudent
-    }
+    },
+    dateOfBirth: rest.dateOfBirth.toISOString()
   }
 }
 
@@ -81,7 +86,8 @@ const toDependentForm = (dependent: Dependent): UserDependentForm => {
     ...rest,
     birthYear: qualifyingInfo?.birthYear.toString() ?? '',
     numberOfMonths: qualifyingInfo?.numberOfMonths.toString() ?? '',
-    isStudent: qualifyingInfo?.isStudent ?? false
+    isStudent: qualifyingInfo?.isStudent ?? false,
+    dateOfBirth: new Date(rest.dateOfBirth)
   }
 }
 
@@ -96,11 +102,13 @@ const blankUserSpouseForm = {
 
 const toSpouse = (formData: UserSpouseForm): Spouse => ({
   ...formData,
-  role: PersonRole.SPOUSE
+  role: PersonRole.SPOUSE,
+  dateOfBirth: formData.dateOfBirth.toISOString()
 })
 
 const toSpouseForm = (spouse: Spouse): UserSpouseForm => ({
-  ...spouse
+  ...spouse,
+  dateOfBirth: new Date(spouse.dateOfBirth)
 })
 
 export const AddDependentForm = (): ReactElement => {

--- a/src/components/TaxPayer/TaxPayer.tsx
+++ b/src/components/TaxPayer/TaxPayer.tsx
@@ -41,6 +41,8 @@ interface TaxPayerUserForm {
   isForeignCountry: boolean
   isTaxpayerDependent: boolean
   stateResidency?: State
+  isBlind: boolean
+  dateOfBirth: Date
 }
 
 const defaultTaxpayerUserForm: TaxPayerUserForm = {
@@ -58,7 +60,9 @@ const defaultTaxpayerUserForm: TaxPayerUserForm = {
     state: undefined,
     zip: undefined
   },
-  isTaxpayerDependent: false
+  isTaxpayerDependent: false,
+  isBlind: false,
+  dateOfBirth: new Date()
 }
 
 const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
@@ -67,7 +71,9 @@ const asPrimaryPerson = (formData: TaxPayerUserForm): PrimaryPerson => ({
   lastName: formData.lastName,
   ssid: formData.ssid.replace(/-/g, ''),
   isTaxpayerDependent: formData.isTaxpayerDependent,
-  role: PersonRole.PRIMARY
+  role: PersonRole.PRIMARY,
+  dateOfBirth: formData.dateOfBirth.toISOString(),
+  isBlind: formData.isBlind
 })
 
 const asContactInfo = (formData: TaxPayerUserForm): ContactInfo => ({
@@ -78,7 +84,8 @@ const asContactInfo = (formData: TaxPayerUserForm): ContactInfo => ({
 const asTaxPayerUserForm = (person: PrimaryPerson): TaxPayerUserForm => ({
   ...person,
   isForeignCountry: person.address.foreignCountry !== undefined,
-  role: PersonRole.PRIMARY
+  role: PersonRole.PRIMARY,
+  dateOfBirth: new Date(person.dateOfBirth)
 })
 
 export default function PrimaryTaxpayer(): ReactElement {

--- a/src/core/data/TaxPayer.ts
+++ b/src/core/data/TaxPayer.ts
@@ -1,18 +1,78 @@
-import { Person, TaxPayer as TP } from '.'
+import { TaxPayer as InfoTaxPayer, PersonRole, Address, FilingStatus } from '.'
+
+interface Person {
+  firstName: string
+  lastName: string
+  ssid: string
+  role: PersonRole
+  dateOfBirth: Date
+  isBlind: boolean
+}
+
+interface QualifyingInformation {
+  numberOfMonths: number
+  isStudent: boolean
+}
+
+export interface Dependent extends Person {
+  relationship: string
+  qualifyingInfo?: QualifyingInformation
+}
+
+interface PrimaryPerson extends Person {
+  address: Address
+  isTaxpayerDependent: boolean
+}
+
+interface Spouse extends Person {
+  isTaxpayerDependent: boolean
+}
+
+interface ContactInfo {
+  contactPhoneNumber?: string
+  contactEmail?: string
+}
+
+interface TP extends ContactInfo {
+  filingStatus?: FilingStatus
+  primaryPerson?: PrimaryPerson
+  spouse?: Spouse
+  dependents: Dependent[]
+}
 
 /**
  * Used to augment the TaxPayer data interface with some convenience
  * methods.
  */
-export default class TaxPayer {
-  tp: TP
+export default class TaxPayer implements TP {
+  primaryPerson?: PrimaryPerson | undefined
+  spouse?: Spouse | undefined
+  dependents: Dependent[]
+  filingStatus?: FilingStatus | undefined
 
-  constructor(tp: TP) {
-    this.tp = tp
+  constructor(tp: InfoTaxPayer) {
+    if (tp.primaryPerson !== undefined) {
+      this.primaryPerson = {
+        ...tp.primaryPerson,
+        dateOfBirth: new Date(tp.primaryPerson.dateOfBirth)
+      }
+    }
+
+    if (tp.spouse !== undefined) {
+      this.spouse = {
+        ...tp.spouse,
+        dateOfBirth: new Date(tp.spouse.dateOfBirth)
+      }
+    }
+
+    this.dependents = tp.dependents.map((d) => {
+      return { ...d, dateOfBirth: new Date(d.dateOfBirth) }
+    })
+    this.filingStatus = tp.filingStatus
   }
 
   namesString = (): string => {
-    const ps: Person[] = [this.tp.primaryPerson, this.tp.spouse]
+    const ps: Person[] = [this.primaryPerson, this.spouse]
       .filter((p: Person | undefined) => p !== undefined)
       .map((p: Person | undefined) => p as Person)
 

--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -25,7 +25,6 @@ export interface Person {
 }
 
 export interface QualifyingInformation {
-  birthYear: number
   numberOfMonths: number
   isStudent: boolean
 }

--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -20,6 +20,8 @@ export interface Person {
   lastName: string
   ssid: string
   role: PersonRole
+  dateOfBirth: string
+  isBlind: boolean
 }
 
 export interface QualifyingInformation {

--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -491,9 +491,8 @@ export class Arbitraries {
 
   qualifyingInformation = (): Arbitrary<types.QualifyingInformation> =>
     fc
-      .tuple(this.birthYear(), fc.nat({ max: 12 }), fc.boolean())
-      .map(([birthYear, numberOfMonths, isStudent]) => ({
-        birthYear,
+      .tuple(fc.nat({ max: 12 }), fc.boolean())
+      .map(([numberOfMonths, isStudent]) => ({
         numberOfMonths,
         isStudent
       }))

--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -374,11 +374,22 @@ export const filingStatus: Arbitrary<types.FilingStatus> = fc.constantFrom(
 )
 
 export const person: Arbitrary<types.Person> = fc
-  .tuple(word, word, ein)
-  .map(([firstName, lastName, ssid]) => ({
+  .tuple(
+    word,
+    word,
+    ein,
+    fc.date({
+      min: new Date(1900, 0, 1),
+      max: new Date()
+    }),
+    fc.boolean()
+  )
+  .map(([firstName, lastName, ssid, dateOfBirth, isBlind]) => ({
     firstName,
     lastName,
     ssid,
+    dateOfBirth: dateOfBirth.toISOString(),
+    isBlind,
     role: types.PersonRole.PRIMARY
   }))
 

--- a/src/forms/Y2020/irsForms/F1040.ts
+++ b/src/forms/Y2020/irsForms/F1040.ts
@@ -8,6 +8,7 @@ import {
   Asset
 } from 'ustaxes/core/data'
 import federalBrackets from '../data/federal'
+import { CURRENT_YEAR } from '../data/federal'
 import F1040V from './F1040v'
 import F2441 from './F2441'
 import F2555 from './F2555'
@@ -277,15 +278,17 @@ export default class F1040 extends Form {
   }
 
   // TODO -> born before 1956/01/02
-  bornBeforeDate = (): boolean => false
-  // TODO
-  blind = (): boolean => false
+  bornBeforeDate = (): boolean =>
+    (this.tp.primaryPerson?.dateOfBirth ?? new Date()) <
+    new Date(CURRENT_YEAR - 64, 0, 2)
 
-  // TODO
-  spouseBeforeDate = (): boolean => false
+  blind = (): boolean => this.tp.primaryPerson?.isBlind ?? false
 
-  // TODO
-  spouseBlind = (): boolean => false
+  spouseBeforeDate = (): boolean =>
+    (this.tp.spouse?.dateOfBirth ?? new Date()) <
+    new Date(CURRENT_YEAR - 64, 0, 2)
+
+  spouseBlind = (): boolean => this.tp.spouse?.isBlind ?? false
 
   validW2s = (): IncomeW2[] => {
     if (this.info.taxPayer.filingStatus === FilingStatus.MFS) {

--- a/src/forms/Y2020/irsForms/F2555.ts
+++ b/src/forms/Y2020/irsForms/F2555.ts
@@ -1,6 +1,6 @@
 import { Field } from 'ustaxes/core/pdfFiller'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 
 /**
  * Impacts EIC, 1040 instructions L27 step 1 question 4

--- a/src/forms/Y2020/irsForms/F4797.ts
+++ b/src/forms/Y2020/irsForms/F4797.ts
@@ -1,5 +1,5 @@
 import { Field } from 'ustaxes/core/pdfFiller'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 
 /**

--- a/src/forms/Y2020/irsForms/F8814.ts
+++ b/src/forms/Y2020/irsForms/F8814.ts
@@ -1,4 +1,4 @@
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import log from 'ustaxes/core/log'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { Field } from 'ustaxes/core/pdfFiller'

--- a/src/forms/Y2020/irsForms/F8949.ts
+++ b/src/forms/Y2020/irsForms/F8949.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import { Asset, TaxPayer as TP } from 'ustaxes/core/data'
+import { Asset } from 'ustaxes/core/data'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
 
 type EmptyLine = [
@@ -57,13 +57,13 @@ export default class F8949 extends Form {
   tag: FormTag = 'f8949'
   sequenceIndex = 12.1
   assets: Asset<Date>[]
-  tp: TP
+  tp: TaxPayer
 
   index = 0
 
   copies: F8949[] = []
 
-  constructor(tp: TP, assets: Asset<Date>[], index = 0) {
+  constructor(tp: TaxPayer, assets: Asset<Date>[], index = 0) {
     super()
     this.assets = assets
     this.tp = tp
@@ -175,9 +175,8 @@ export default class F8949 extends Form {
   longTermTotalAdjustments = (): number | undefined => undefined
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.tp)
     return [
-      tp.namesString(),
+      this.tp.namesString(),
       this.tp.primaryPerson?.ssid,
       this.part1BoxA(),
       this.part1BoxB(),
@@ -188,7 +187,7 @@ export default class F8949 extends Form {
       undefined, // greyed out field
       this.shortTermTotalAdjustments(),
       this.shortTermTotalGain(),
-      tp.namesString(),
+      this.tp.namesString(),
       this.tp.primaryPerson?.ssid,
       this.part2BoxD(),
       this.part2BoxE(),

--- a/src/forms/Y2020/irsForms/F8959.ts
+++ b/src/forms/Y2020/irsForms/F8959.ts
@@ -100,7 +100,7 @@ export default class F8959 extends Form {
     const tp = new TaxPayer(this.state.taxPayer)
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2020/irsForms/F8960.ts
+++ b/src/forms/Y2020/irsForms/F8960.ts
@@ -1,6 +1,5 @@
 import { Information } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { netInvestmentIncomeTax } from '../data/federal'
 import F1040 from './F1040'
@@ -133,10 +132,10 @@ export default class F8960 extends Form {
   l21 = (): number | undefined => undefined // Math.round(this.l20() * netInvestmentIncomeTax.taxRate)
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       undefined, // Section 6013(g) election checkbox
       undefined, // Section 6013(h) election checkbox
       undefined, // Regulations section 1.1411-10(g) election checkbox

--- a/src/forms/Y2020/irsForms/Schedule1.ts
+++ b/src/forms/Y2020/irsForms/Schedule1.ts
@@ -1,5 +1,4 @@
 import { Information } from 'ustaxes/core/data'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import ScheduleE from './ScheduleE'
 import { sumFields } from 'ustaxes/core/irsForms/util'
@@ -110,11 +109,11 @@ export default class Schedule1 extends Form {
   }
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2a(),
       this.l2b(),

--- a/src/forms/Y2020/irsForms/Schedule2.ts
+++ b/src/forms/Y2020/irsForms/Schedule2.ts
@@ -13,7 +13,7 @@ export default class Schedule2 extends Form {
 
   constructor(tp: TP, f1040: F1040) {
     super()
-    this.tp = new TaxPayer(tp)
+    this.tp = f1040.tp
     this.f1040 = f1040
     this.otherIncomeStrings = new Set<string>()
   }
@@ -70,7 +70,7 @@ export default class Schedule2 extends Form {
   fields = (): Array<string | number | boolean | undefined> => {
     return [
       this.tp.namesString(),
-      this.tp.tp.primaryPerson?.ssid,
+      this.tp.primaryPerson?.ssid,
 
       this.l1(),
       this.l2(),

--- a/src/forms/Y2020/irsForms/Schedule3.ts
+++ b/src/forms/Y2020/irsForms/Schedule3.ts
@@ -1,7 +1,6 @@
-import { Information, IncomeW2, PersonRole } from 'ustaxes/core/data'
+import { IncomeW2, PersonRole } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import { fica } from '../data/federal'
 import F1040 from './F1040'
 
@@ -44,12 +43,10 @@ export const claimableExcessSSTaxWithholding = (w2s: IncomeW2[]): number => {
 export default class Schedule3 extends Form {
   tag: FormTag = 'f1040s3'
   sequenceIndex = 3
-  state: Information
   f1040: F1040
 
-  constructor(state: Information, f1040: F1040) {
+  constructor(f1040: F1040) {
     super()
-    this.state = state
     this.f1040 = f1040
   }
 
@@ -85,10 +82,10 @@ export default class Schedule3 extends Form {
     sumFields([this.l8(), this.l9(), this.l10(), this.l11(), this.l12f()])
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2020/irsForms/Schedule8812.ts
+++ b/src/forms/Y2020/irsForms/Schedule8812.ts
@@ -11,7 +11,7 @@ export default class Schedule8812 extends Form {
 
   constructor(f1040: F1040) {
     super()
-    this.tp = new TaxPayer(f1040.info.taxPayer)
+    this.tp = f1040.tp
     this.f1040 = f1040
   }
 
@@ -101,7 +101,7 @@ export default class Schedule8812 extends Form {
   fields = (): Array<string | number | boolean | undefined> => {
     return [
       this.tp.namesString(),
-      this.tp.tp.primaryPerson?.ssid,
+      this.tp.primaryPerson?.ssid,
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2020/irsForms/ScheduleB.ts
+++ b/src/forms/Y2020/irsForms/ScheduleB.ts
@@ -1,4 +1,3 @@
-import { Information } from 'ustaxes/core/data'
 import InformationMethods from 'ustaxes/core/data/methods'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
@@ -13,15 +12,17 @@ export default class ScheduleB extends Form {
   tag: FormTag = 'f1040sb'
   sequenceIndex = 8
   state: InformationMethods
+  tp: TaxPayer
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16
 
   index = 0
   copies: ScheduleB[] = []
 
-  constructor(info: Information, index = 0) {
+  constructor(info: InformationMethods, tp: TaxPayer, index = 0) {
     super()
-    this.state = new InformationMethods(info)
+    this.state = info
+    this.tp = tp
 
     this.index = index
 
@@ -37,7 +38,7 @@ export default class ScheduleB extends Form {
       )
 
       this.copies = Array.from(Array(extraCopiesNeeded)).map(
-        (_, i) => new ScheduleB(info, i + 1)
+        (_, i) => new ScheduleB(info, tp, i + 1)
       )
     }
   }
@@ -124,11 +125,9 @@ export default class ScheduleB extends Form {
   l8 = (): [boolean, boolean] => [this.foreignTrust(), !this.foreignTrust()]
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
-
     const result = [
-      tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      this.tp.namesString(),
+      this.tp.primaryPerson?.ssid ?? '',
       ...this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2020/irsForms/ScheduleD.ts
+++ b/src/forms/Y2020/irsForms/ScheduleD.ts
@@ -248,7 +248,7 @@ export default class ScheduleD extends Form {
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       false,
       false,
       this.l1ad(),

--- a/src/forms/Y2020/irsForms/ScheduleE.ts
+++ b/src/forms/Y2020/irsForms/ScheduleE.ts
@@ -214,7 +214,7 @@ export default class ScheduleE extends Form {
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       false,
       false,
       false,
@@ -259,7 +259,7 @@ export default class ScheduleE extends Form {
       displayNegPos(this.l26()),
       // Page 2 - TODO: completely unimplemented
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       ...[false, false], // l27
       ...Array(6 * 4 + 5 * 4).fill(undefined), // l28
       undefined, // grey

--- a/src/forms/Y2020/irsForms/ScheduleEIC.ts
+++ b/src/forms/Y2020/irsForms/ScheduleEIC.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
-import { Dependent, FilingStatus, TaxPayer as TP } from 'ustaxes/core/data'
+import { FilingStatus } from 'ustaxes/core/data'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
+import { Dependent } from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { evaluatePiecewise, Piecewise } from 'ustaxes/core/util'
 import { sumFields } from 'ustaxes/core/irsForms/util'
@@ -52,25 +53,25 @@ export default class ScheduleEIC extends Form {
   f4797?: F4797
   f8814?: F8814
   pub596Worksheet1: Pub596Worksheet1
-  qualifyingStudentCutoffYear = 1996
-  qualifyingCutoffYear = 2001
+  qualifyingStudentCutoffYear = new Date(1996, 0, 1)
+  qualifyingCutoffYear = new Date(2001, 0, 1)
   investmentIncomeLimit = 3650
   f1040: F1040
 
-  constructor(tp: TP, f1040: F1040) {
+  constructor(f1040: F1040) {
     super()
-    this.tp = new TaxPayer(tp)
-    this.f2555 = new F2555(tp)
-    this.f4797 = new F4797(tp)
-    this.f8814 = new F8814(tp)
+    this.tp = f1040.tp
+    this.f2555 = new F2555(this.tp)
+    this.f4797 = new F4797(this.tp)
+    this.f8814 = new F8814(this.tp)
     this.f1040 = f1040
-    this.pub596Worksheet1 = new Pub596Worksheet1(tp, f1040)
+    this.pub596Worksheet1 = new Pub596Worksheet1(this.tp, f1040)
   }
 
   // instructions step 1.1
   passIncomeLimit = (f1040: F1040): boolean => {
-    if (this.tp.tp.filingStatus !== undefined) {
-      const incomeLimits = federal.EIC.caps[this.tp.tp.filingStatus]
+    if (this.tp.filingStatus !== undefined) {
+      const incomeLimits = federal.EIC.caps[this.tp.filingStatus]
       if (incomeLimits !== undefined) {
         const limit =
           incomeLimits[
@@ -93,8 +94,7 @@ export default class ScheduleEIC extends Form {
   }
 
   // Step 1.3
-  allowedFilingStatus = (): boolean =>
-    this.tp.tp.filingStatus !== FilingStatus.MFS
+  allowedFilingStatus = (): boolean => this.tp.filingStatus !== FilingStatus.MFS
 
   // Step 1.4
   allowedFilling2555 = (): boolean => !precludesEIC(checks2555)(this.f2555)
@@ -145,7 +145,7 @@ export default class ScheduleEIC extends Form {
   atLeastOneChild = (): boolean => this.qualifyingDependents().length > 0
 
   // 3.2, 4.4
-  jointReturn = (): boolean => this.tp.tp.filingStatus === FilingStatus.MFJ
+  jointReturn = (): boolean => this.tp.filingStatus === FilingStatus.MFJ
 
   // 3.3, 4.5
   qualifyingChildOfAnother = (): boolean => {
@@ -170,8 +170,8 @@ export default class ScheduleEIC extends Form {
   // 4.5 covered above
   // 4.6 dependent of another
   dependentOfAnother = (): boolean =>
-    (this.tp.tp.primaryPerson?.isTaxpayerDependent ?? false) ||
-    (this.tp.tp.spouse?.isTaxpayerDependent ?? false)
+    (this.tp.primaryPerson?.isTaxpayerDependent ?? false) ||
+    (this.tp.spouse?.isTaxpayerDependent ?? false)
 
   // 5.1 - Filing schedule SE for church
   filingSEChurchIncome = (): boolean => {
@@ -264,11 +264,11 @@ export default class ScheduleEIC extends Form {
    * @returns
    */
   calculateEICForIncome = (income: number): number => {
-    if (this.tp.tp.filingStatus === undefined) {
+    if (this.tp.filingStatus === undefined) {
       return 0
     }
     const f: Piecewise[] | undefined =
-      federal.EIC.formulas[this.tp.tp.filingStatus]
+      federal.EIC.formulas[this.tp.filingStatus]
     if (f === undefined) {
       return 0
     }
@@ -321,26 +321,22 @@ export default class ScheduleEIC extends Form {
         this.passPub596()) &&
       !(
         // Step 4
-        (
-          this.tp.tp.filingStatus !== FilingStatus.MFJ &&
-          this.dependentOfAnother()
-        )
+        (this.tp.filingStatus !== FilingStatus.MFJ && this.dependentOfAnother())
       ) &&
       this.credit(f1040) > 0
     )
   }
 
   qualifyingDependents = (): Dependent[] =>
-    this.tp.tp.dependents
+    this.tp.dependents
       .filter(
         (d) =>
-          d.qualifyingInfo?.birthYear !== undefined &&
-          ((d.qualifyingInfo?.birthYear !== undefined &&
-            d.qualifyingInfo?.birthYear >= this.qualifyingCutoffYear) ||
-            ((d.qualifyingInfo?.isStudent ?? false) &&
-              d.qualifyingInfo?.birthYear >= this.qualifyingStudentCutoffYear))
+          (d.dateOfBirth !== undefined &&
+            d.dateOfBirth >= this.qualifyingCutoffYear) ||
+          ((d.qualifyingInfo?.isStudent ?? false) &&
+            d.dateOfBirth >= this.qualifyingStudentCutoffYear)
       )
-      .sort((d) => d.qualifyingInfo?.birthYear as number)
+      .sort((d) => d.dateOfBirth.getFullYear())
       .slice(0, 3)
 
   qualifyingDependentsFilled = (): Array<Dependent | undefined> => {
@@ -359,7 +355,7 @@ export default class ScheduleEIC extends Form {
     this.qualifyingDependentsFilled().map((d) => d?.ssid)
 
   years = (): Array<number | undefined> =>
-    this.qualifyingDependentsFilled().map((d) => d?.qualifyingInfo?.birthYear)
+    this.qualifyingDependentsFilled().map((d) => d?.dateOfBirth?.getFullYear())
 
   // EIC line 3
   birthYearFields = (): Array<string | undefined> =>
@@ -383,7 +379,10 @@ export default class ScheduleEIC extends Form {
   // TODO: disability
   disabledFields = (): Array<boolean | undefined> =>
     this.years().flatMap((year) => {
-      if (year === undefined || year < this.qualifyingCutoffYear) {
+      if (
+        year === undefined ||
+        year < this.qualifyingCutoffYear.getFullYear()
+      ) {
         return [undefined, undefined]
       }
       return [undefined, undefined]
@@ -400,7 +399,7 @@ export default class ScheduleEIC extends Form {
 
   fields = (): Array<string | number | boolean | undefined> => [
     this.tp.namesString(),
-    this.tp.tp.primaryPerson?.ssid,
+    this.tp.primaryPerson?.ssid,
     ...this.nameFields(), // 6
     ...this.ssnFields(), // 3
     ...this.birthYearFields(), // 12

--- a/src/forms/Y2020/irsForms/worksheets/ChildTaxCreditWorksheet.ts
+++ b/src/forms/Y2020/irsForms/worksheets/ChildTaxCreditWorksheet.ts
@@ -1,31 +1,35 @@
 import F1040 from '../../irsForms/F1040'
-import { Dependent, FilingStatus } from 'ustaxes/core/data'
+import { FilingStatus } from 'ustaxes/core/data'
+import { Dependent } from 'ustaxes/core/data/TaxPayer'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import { QualifyingDependents } from '../../data/federal'
 
 export default class ChildTaxCreditWorksheet {
   f1040: F1040
+  tp: TaxPayer
   year = 2020
 
   constructor(f1040: F1040) {
     this.f1040 = f1040
+    this.tp = new TaxPayer(this.f1040.info.taxPayer)
   }
 
   qualifiesChild = (d: Dependent): boolean =>
     d.qualifyingInfo !== undefined &&
-    this.year - d.qualifyingInfo.birthYear < QualifyingDependents.childMaxAge
+    this.year - d.dateOfBirth.getFullYear() < QualifyingDependents.childMaxAge
 
   qualifiesOther = (d: Dependent): boolean =>
     d.qualifyingInfo !== undefined &&
     !this.qualifiesChild(d) &&
-    this.year - d.qualifyingInfo.birthYear <
+    this.year - d.dateOfBirth.getFullYear() <
       (d.qualifyingInfo.isStudent
         ? QualifyingDependents.qualifyingDependentMaxAge
         : QualifyingDependents.qualifyingStudentMaxAge)
 
   // worksheet line 1
   numberQualifyingChildren = (): number =>
-    this.f1040.info.taxPayer.dependents.reduce(
+    this.tp.dependents.reduce(
       (total, dependent) =>
         this.qualifiesChild(dependent) ? total + 1 : total,
       0
@@ -35,7 +39,7 @@ export default class ChildTaxCreditWorksheet {
 
   // worksheet line 2
   numberQualifyingOtherDependents = (): number =>
-    this.f1040.info.taxPayer.dependents.reduce(
+    this.tp.dependents.reduce(
       (total, dependent) =>
         this.qualifiesOther(dependent) ? total : total + 1,
       0

--- a/src/forms/Y2020/irsForms/worksheets/Pub596Worksheet1.ts
+++ b/src/forms/Y2020/irsForms/worksheets/Pub596Worksheet1.ts
@@ -1,5 +1,5 @@
 import { EIC } from '../../data/federal'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import { ifNegative, ifPositive } from 'ustaxes/core/util'
 import F1040 from '../../irsForms/F1040'
 import { sumFields } from 'ustaxes/core/irsForms/util'

--- a/src/forms/Y2020/stateForms/IL/IL1040ScheduleILEIC.ts
+++ b/src/forms/Y2020/stateForms/IL/IL1040ScheduleILEIC.ts
@@ -1,7 +1,8 @@
 import Form from 'ustaxes/core/stateForms/Form'
 import F1040 from '../../irsForms/F1040'
 import { Field } from 'ustaxes/core/pdfFiller'
-import { Dependent, Information, State } from 'ustaxes/core/data'
+import { Information, State } from 'ustaxes/core/data'
+import { Dependent } from 'ustaxes/core/data/TaxPayer'
 import parameters from './Parameters'
 
 export class IL1040scheduleileeic extends Form {

--- a/src/forms/Y2021/irsForms/F1040.ts
+++ b/src/forms/Y2021/irsForms/F1040.ts
@@ -8,6 +8,7 @@ import {
   Asset
 } from 'ustaxes/core/data'
 import federalBrackets from '../data/federal'
+import { CURRENT_YEAR } from '../data/federal'
 import F4972 from './F4972'
 import F5695 from './F5695'
 import F8814 from './F8814'
@@ -342,16 +343,18 @@ export default class F1040 extends Form {
     }
   }
 
-  // TODO -> born before 1956/01/02
-  bornBeforeDate = (): boolean => false
-  // TODO
-  blind = (): boolean => false
+  // born before 1957/01/02
+  bornBeforeDate = (): boolean =>
+    (this.tp.primaryPerson?.dateOfBirth ?? new Date()) <
+    new Date(CURRENT_YEAR - 64, 0, 2)
 
-  // TODO
-  spouseBeforeDate = (): boolean => false
+  blind = (): boolean => this.tp.primaryPerson?.isBlind ?? false
 
-  // TODO
-  spouseBlind = (): boolean => false
+  spouseBeforeDate = (): boolean =>
+    (this.tp.spouse?.dateOfBirth ?? new Date()) <
+    new Date(CURRENT_YEAR - 64, 0, 2)
+
+  spouseBlind = (): boolean => this.tp.spouse?.isBlind ?? false
 
   validW2s = (): IncomeW2[] => {
     if (this.info.taxPayer.filingStatus === FilingStatus.MFS) {

--- a/src/forms/Y2021/irsForms/F2555.ts
+++ b/src/forms/Y2021/irsForms/F2555.ts
@@ -1,6 +1,6 @@
 import { Field } from 'ustaxes/core/pdfFiller'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 
 /**
  * Impacts EIC, 1040 instructions L27 step 1 squestion 4

--- a/src/forms/Y2021/irsForms/F4797.ts
+++ b/src/forms/Y2021/irsForms/F4797.ts
@@ -1,5 +1,5 @@
 import { Field } from 'ustaxes/core/pdfFiller'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 
 /**

--- a/src/forms/Y2021/irsForms/F6251.ts
+++ b/src/forms/Y2021/irsForms/F6251.ts
@@ -1,5 +1,4 @@
 import { FilingStatus, Information, PersonRole } from 'ustaxes/core/data'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import F1040 from './F1040'
 import SDQualifiedAndCapGains from './worksheets/SDQualifiedAndCapGains'
@@ -579,10 +578,10 @@ export default class F6251 extends Form {
   }
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       // Part I
       this.l1(),
       this.l2a(),

--- a/src/forms/Y2021/irsForms/F8814.ts
+++ b/src/forms/Y2021/irsForms/F8814.ts
@@ -1,4 +1,4 @@
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import log from 'ustaxes/core/log'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { Field } from 'ustaxes/core/pdfFiller'

--- a/src/forms/Y2021/irsForms/F8949.ts
+++ b/src/forms/Y2021/irsForms/F8949.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import { Asset, TaxPayer as TP } from 'ustaxes/core/data'
+import { Asset } from 'ustaxes/core/data'
 import TaxPayer from 'ustaxes/core/data/TaxPayer'
 
 type EmptyLine = [
@@ -57,13 +57,13 @@ export default class F8949 extends Form {
   tag: FormTag = 'f8949'
   sequenceIndex = 12.1
   assets: Asset<Date>[]
-  tp: TP
+  tp: TaxPayer
 
   index = 0
 
   copies: F8949[] = []
 
-  constructor(tp: TP, assets: Asset<Date>[], index = 0) {
+  constructor(tp: TaxPayer, assets: Asset<Date>[], index = 0) {
     super()
     this.assets = assets
     this.tp = tp
@@ -176,9 +176,8 @@ export default class F8949 extends Form {
   longTermTotalAdjustments = (): number | undefined => undefined
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.tp)
     return [
-      tp.namesString(),
+      this.tp.namesString(),
       this.tp.primaryPerson?.ssid,
       this.part1BoxA(),
       this.part1BoxB(),
@@ -189,7 +188,7 @@ export default class F8949 extends Form {
       undefined, // greyed out field
       this.shortTermTotalAdjustments(),
       this.shortTermTotalGain(),
-      tp.namesString(),
+      this.tp.namesString(),
       this.tp.primaryPerson?.ssid,
       this.part2BoxD(),
       this.part2BoxE(),

--- a/src/forms/Y2021/irsForms/F8959.ts
+++ b/src/forms/Y2021/irsForms/F8959.ts
@@ -109,7 +109,7 @@ export default class F8959 extends Form {
     const tp = new TaxPayer(this.state.taxPayer)
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2021/irsForms/F8960.ts
+++ b/src/forms/Y2021/irsForms/F8960.ts
@@ -1,6 +1,5 @@
 import { Information } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { netInvestmentIncomeTax } from '../data/federal'
 import F1040 from './F1040'
@@ -148,10 +147,10 @@ export default class F8960 extends Form {
   toSchedule2l12 = (): number | undefined => this.l17()
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       undefined, // Section 6013(g) election checkbox
       undefined, // Section 6013(h) election checkbox
       undefined, // Regulations section 1.1411-10(g) election checkbox

--- a/src/forms/Y2021/irsForms/F8995.ts
+++ b/src/forms/Y2021/irsForms/F8995.ts
@@ -1,5 +1,4 @@
 import F1040 from './F1040'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { FilingStatus } from 'ustaxes/core/data'
 
@@ -75,11 +74,11 @@ export default class F8995 extends Form {
   deductions = (): number => this.l15()
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.f1040.info.taxPayer)
+    const tp = this.f1040.tp
 
     const result = [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      tp.primaryPerson?.ssid ?? '',
       this.applicableK1s()[0]?.partnershipName,
       this.applicableK1s()[0]?.partnershipEin,
       this.applicableK1s()[0]?.section199AQBI,

--- a/src/forms/Y2021/irsForms/F8995A.ts
+++ b/src/forms/Y2021/irsForms/F8995A.ts
@@ -158,7 +158,7 @@ export default class F8995A extends F8995 {
 
     const result = [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      tp.primaryPerson?.ssid ?? '',
       this.applicableK1s()[0]?.partnershipName,
       false, // 1Ab
       false, // 1Ac

--- a/src/forms/Y2021/irsForms/Schedule1.ts
+++ b/src/forms/Y2021/irsForms/Schedule1.ts
@@ -1,5 +1,4 @@
 import { Information } from 'ustaxes/core/data'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import ScheduleE from './ScheduleE'
 import { sumFields } from 'ustaxes/core/irsForms/util'
@@ -166,11 +165,11 @@ export default class Schedule1 extends Form {
   to1040Line10 = (): number => this.l26()
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2a(),
       this.l2b(),

--- a/src/forms/Y2021/irsForms/Schedule2.ts
+++ b/src/forms/Y2021/irsForms/Schedule2.ts
@@ -1,7 +1,6 @@
-import { TaxPayer as TP } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
 import { sumFields } from 'ustaxes/core/irsForms/util'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import F1040 from './F1040'
 
 export default class Schedule2 extends Form {
@@ -10,9 +9,9 @@ export default class Schedule2 extends Form {
   tp: TaxPayer
   f1040: F1040
 
-  constructor(tp: TP, f1040: F1040) {
+  constructor(tp: TaxPayer, f1040: F1040) {
     super()
-    this.tp = new TaxPayer(tp)
+    this.tp = tp
     this.f1040 = f1040
   }
 
@@ -138,7 +137,7 @@ export default class Schedule2 extends Form {
   fields = (): Array<string | number | boolean | undefined> => {
     return [
       this.tp.namesString(),
-      this.tp.tp.primaryPerson?.ssid,
+      this.tp.primaryPerson?.ssid,
 
       this.l1(),
       this.l2(),

--- a/src/forms/Y2021/irsForms/Schedule3.ts
+++ b/src/forms/Y2021/irsForms/Schedule3.ts
@@ -1,7 +1,6 @@
 import { Information, IncomeW2, PersonRole } from 'ustaxes/core/data'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import { fica } from '../data/federal'
 import F1040 from './F1040'
 
@@ -161,10 +160,10 @@ export default class Schedule3 extends Form {
   // Credit for child and dependent care expenses form 2441, line 10
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
+    const tp = this.f1040.tp
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2021/irsForms/Schedule8812.ts
+++ b/src/forms/Y2021/irsForms/Schedule8812.ts
@@ -1,5 +1,4 @@
 import { FilingStatus } from 'ustaxes/core/data'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import F1040 from './F1040'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
@@ -111,10 +110,8 @@ export default class Schedule8812 extends Form {
 
   // Number of qualifying children under age 6 at EOY
   l4b = (): number =>
-    this.f1040.info.taxPayer.dependents.filter(
-      (d) =>
-        d.qualifyingInfo !== undefined &&
-        d.qualifyingInfo.birthYear > CURRENT_YEAR - 6
+    this.f1040.tp.dependents.filter(
+      (d) => d.dateOfBirth.getFullYear() > CURRENT_YEAR - 6
     ).length
 
   l4c = (): number => Math.max(0, this.l4a() - this.l4b())
@@ -524,7 +521,7 @@ export default class Schedule8812 extends Form {
   l40 = (): number => this.part3().l40 ?? 0
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.f1040.info.taxPayer)
+    const tp = this.f1040.tp
 
     const part1b = this.part1b()
     const part1c = this.part1c()
@@ -534,7 +531,7 @@ export default class Schedule8812 extends Form {
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       this.l1(),
       this.l2a(),
       this.l2b(),

--- a/src/forms/Y2021/irsForms/ScheduleA.ts
+++ b/src/forms/Y2021/irsForms/ScheduleA.ts
@@ -1,6 +1,5 @@
 import { FilingStatus, ItemizedDeductions } from 'ustaxes/core/data'
 import Form, { FormTag } from 'ustaxes/core/irsForms/Form'
-import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import F1040 from './F1040'
 
 export default class ScheduleA extends Form {
@@ -115,11 +114,11 @@ export default class ScheduleA extends Form {
   l18 = (): boolean => false
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.f1040.info.taxPayer)
+    const tp = this.f1040.tp
 
     const result = [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      tp.primaryPerson?.ssid ?? '',
       this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2021/irsForms/ScheduleB.ts
+++ b/src/forms/Y2021/irsForms/ScheduleB.ts
@@ -13,15 +13,17 @@ export default class ScheduleB extends Form {
   tag: FormTag = 'f1040sb'
   sequenceIndex = 8
   state: InformationMethods
+  tp: TaxPayer
   readonly interestPayersLimit = 14
   readonly dividendPayersLimit = 16
 
   index = 0
   copies: ScheduleB[] = []
 
-  constructor(info: Information, index = 0) {
+  constructor(info: Information, tp: TaxPayer, index = 0) {
     super()
     this.state = new InformationMethods(info)
+    this.tp = tp
     this.index = index
 
     if (index === 0) {
@@ -36,7 +38,7 @@ export default class ScheduleB extends Form {
       )
 
       this.copies = Array.from(Array(extraCopiesNeeded)).map(
-        (_, i) => new ScheduleB(info, i + 1)
+        (_, i) => new ScheduleB(info, tp, i + 1)
       )
     }
   }
@@ -130,11 +132,9 @@ export default class ScheduleB extends Form {
   l8 = (): [boolean, boolean] => [this.foreignTrust(), !this.foreignTrust()]
 
   fields = (): Array<string | number | boolean | undefined> => {
-    const tp = new TaxPayer(this.state.taxPayer)
-
     const result = [
-      tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      this.tp.namesString(),
+      this.tp.primaryPerson?.ssid,
       ...this.l1(),
       this.l2(),
       this.l3(),

--- a/src/forms/Y2021/irsForms/ScheduleD.ts
+++ b/src/forms/Y2021/irsForms/ScheduleD.ts
@@ -248,7 +248,7 @@ export default class ScheduleD extends Form {
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       false,
       false,
       this.l1ad(),

--- a/src/forms/Y2021/irsForms/ScheduleE.ts
+++ b/src/forms/Y2021/irsForms/ScheduleE.ts
@@ -275,7 +275,7 @@ export default class ScheduleE extends Form {
 
     return [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       false,
       false,
       false,
@@ -320,7 +320,7 @@ export default class ScheduleE extends Form {
       displayNegPos(this.l26()),
       // Page 2 - TODO: Only part II implemented
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid,
+      tp.primaryPerson?.ssid,
       ...[false, false], // l27
       ...l28Fields,
       undefined, // grey

--- a/src/forms/Y2021/irsForms/ScheduleSE.ts
+++ b/src/forms/Y2021/irsForms/ScheduleSE.ts
@@ -113,7 +113,7 @@ export default class ScheduleSE extends Form {
 
     const result = [
       tp.namesString(),
-      tp.tp.primaryPerson?.ssid ?? '',
+      tp.primaryPerson?.ssid ?? '',
       false, // Minister
       this.l1a(),
       this.l1b(),

--- a/src/forms/Y2021/irsForms/worksheets/ChildTaxCreditWorksheet.ts
+++ b/src/forms/Y2021/irsForms/worksheets/ChildTaxCreditWorksheet.ts
@@ -1,5 +1,6 @@
 import F1040 from '../../irsForms/F1040'
-import { Dependent, FilingStatus } from 'ustaxes/core/data'
+import { FilingStatus } from 'ustaxes/core/data'
+import { Dependent } from 'ustaxes/core/data/TaxPayer'
 import { sumFields } from 'ustaxes/core/irsForms/util'
 import { QualifyingDependents } from '../../data/federal'
 
@@ -13,19 +14,19 @@ export default class ChildTaxCreditWorksheet {
 
   qualifiesChild = (d: Dependent): boolean =>
     d.qualifyingInfo !== undefined &&
-    this.year - d.qualifyingInfo.birthYear < QualifyingDependents.childMaxAge
+    this.year - d.dateOfBirth.getFullYear() < QualifyingDependents.childMaxAge
 
   qualifiesOther = (d: Dependent): boolean =>
     d.qualifyingInfo !== undefined &&
     !this.qualifiesChild(d) &&
-    this.year - d.qualifyingInfo.birthYear <
+    this.year - d.dateOfBirth.getFullYear() <
       (d.qualifyingInfo.isStudent
         ? QualifyingDependents.qualifyingDependentMaxAge
         : QualifyingDependents.qualifyingStudentMaxAge)
 
   // worksheet line 1
   numberQualifyingChildren = (): number =>
-    this.f1040.info.taxPayer.dependents.reduce(
+    this.f1040.tp.dependents.reduce(
       (total, dependent) =>
         this.qualifiesChild(dependent) ? total + 1 : total,
       0
@@ -35,7 +36,7 @@ export default class ChildTaxCreditWorksheet {
 
   // worksheet line 2
   numberQualifyingOtherDependents = (): number =>
-    this.f1040.info.taxPayer.dependents.reduce(
+    this.f1040.tp.dependents.reduce(
       (total, dependent) =>
         this.qualifiesOther(dependent) ? total : total + 1,
       0

--- a/src/forms/Y2021/irsForms/worksheets/Pub596Worksheet1.ts
+++ b/src/forms/Y2021/irsForms/worksheets/Pub596Worksheet1.ts
@@ -1,5 +1,5 @@
 import { EIC } from '../../data/federal'
-import { TaxPayer } from 'ustaxes/core/data'
+import TaxPayer from 'ustaxes/core/data/TaxPayer'
 import { ifNegative, ifPositive } from 'ustaxes/core/util'
 import F1040 from '../../irsForms/F1040'
 import { sumFields } from 'ustaxes/core/irsForms/util'

--- a/src/forms/Y2021/stateForms/IL/IL1040ScheduleILEIC.ts
+++ b/src/forms/Y2021/stateForms/IL/IL1040ScheduleILEIC.ts
@@ -1,7 +1,8 @@
 import Form from 'ustaxes/core/stateForms/Form'
 import F1040 from '../../irsForms/F1040'
 import { Field } from 'ustaxes/core/pdfFiller'
-import { Dependent, Information, State } from 'ustaxes/core/data'
+import { Information, State } from 'ustaxes/core/data'
+import { Dependent } from 'ustaxes/core/data/TaxPayer'
 import parameters from './Parameters'
 
 export class IL1040scheduleileeic extends Form {

--- a/src/tests/components/SpouseAndDependent/Dependent.test.tsx
+++ b/src/tests/components/SpouseAndDependent/Dependent.test.tsx
@@ -61,7 +61,7 @@ describe('Dependents', () => {
       'Last Name',
       'SSN / TIN',
       'Relationship to Taxpayer',
-      'Birth Year',
+      'Date of Birth',
       'How many months did you live together this year?',
       'Is this person a full-time student?'
     ]
@@ -150,8 +150,8 @@ describe('Dependents', () => {
       newFirstNameInput,
       newLastNameInput,
       newSsnInput,
+      newDAteOfBirthInput,
       newRelationInput,
-      newBirthYearInput,
       newDurationInput
     ] = newInputs
 
@@ -160,7 +160,7 @@ describe('Dependents', () => {
     userEvent.clear(newSsnInput)
     userEvent.type(newSsnInput, '333333333')
     userEvent.type(newRelationInput, 'Daughter')
-    userEvent.type(newBirthYearInput, '2002')
+    userEvent.type(newDAteOfBirthInput, '2002-01-01')
     userEvent.type(newDurationInput, '12')
     userEvent.click(dependent.q.isStudent()!)
 
@@ -265,8 +265,8 @@ describe('Dependents', () => {
       newFirstNameInput,
       newLastNameInput,
       newSsnInput,
+      newDAteOfBirthInput,
       newRelationInput,
-      newBirthYearInput,
       newDurationInput
     ] = newInputs
 
@@ -275,7 +275,7 @@ describe('Dependents', () => {
     userEvent.clear(newSsnInput)
     userEvent.type(newSsnInput, '333333333')
     userEvent.type(newRelationInput, 'Daughter')
-    userEvent.type(newBirthYearInput, '2002')
+    userEvent.type(newDAteOfBirthInput, '2002-0101')
     userEvent.type(newDurationInput, '12')
     userEvent.click(dependent.q.isStudent()!)
     userEvent.click(await dependent.saveButton())
@@ -309,8 +309,8 @@ describe('Dependents', () => {
       filledFirstNameInput,
       filledLastNameInput,
       filledSsnInput,
+      filledDateOfBirthInput,
       filledRelationInput,
-      filledBirthYearInput,
       filledDurationInput
     ] = filledInputs as HTMLInputElement[]
 
@@ -318,7 +318,7 @@ describe('Dependents', () => {
     expect(filledLastNameInput.value).toBe('Brown')
     expect(filledSsnInput.value).toBe('222-22-2222')
     expect(filledRelationInput.value).toBe('Son')
-    expect(filledBirthYearInput.value).toBe('1999')
+    expect(filledDateOfBirthInput.value).toBe('1999-01-01')
     expect(filledDurationInput.value).toBe('12')
     expect(filledFirstNameInput.value).toBe('Charlie')
 
@@ -367,7 +367,7 @@ describe('Dependents', () => {
       'Last Name',
       'SSN / TIN',
       'Relationship to Taxpayer',
-      'Birth Year',
+      'Date of Birth',
       'How many months did you live together this year?',
       'Is this person a full-time student?'
     ]
@@ -385,7 +385,7 @@ describe('Dependents', () => {
 
     // expect six `Input is required` errors
     await waitFor(async () =>
-      expect(dependent.requiredErrors()).toHaveLength(6)
+      expect(dependent.requiredErrors()).toHaveLength(5)
     )
 
     const inputs = spouseAndDependent.rendered().getAllByRole('textbox')
@@ -408,7 +408,7 @@ describe('Dependents', () => {
           .queryByText('Input should only include letters and spaces')
       ).not.toBeInTheDocument()
 
-      expect(dependent.requiredErrors()).toHaveLength(5)
+      expect(dependent.requiredErrors()).toHaveLength(4)
     })
 
     userEvent.clear(firstNameInput)
@@ -422,7 +422,7 @@ describe('Dependents', () => {
           .queryByText('Input should only include letters and spaces')
       ).not.toBeInTheDocument()
 
-      expect(dependent.requiredErrors()).toHaveLength(5)
+      expect(dependent.requiredErrors()).toHaveLength(4)
     })
 
     userEvent.type(lastNameInput, '666')
@@ -436,7 +436,7 @@ describe('Dependents', () => {
       ).not.toBeInTheDocument()
     )
 
-    expect(dependent.requiredErrors()).toHaveLength(4)
+    expect(dependent.requiredErrors()).toHaveLength(3)
 
     userEvent.type(lastNameInput, '{selectall}{del}Washington')
     userEvent.click(await dependent.saveButton())
@@ -448,7 +448,7 @@ describe('Dependents', () => {
           .queryByText('Input should only include letters and spaces')
       ).not.toBeInTheDocument()
     )
-    expect(dependent.requiredErrors()).toHaveLength(4)
+    expect(dependent.requiredErrors()).toHaveLength(3)
 
     userEvent.clear(ssnInput)
     userEvent.type(ssnInput, '123')
@@ -462,7 +462,7 @@ describe('Dependents', () => {
       ).toHaveLength(1)
     )
 
-    expect(dependent.requiredErrors()).toHaveLength(3)
+    expect(dependent.requiredErrors()).toHaveLength(2)
 
     userEvent.clear(ssnInput)
     userEvent.type(ssnInput, '123456789')
@@ -476,7 +476,7 @@ describe('Dependents', () => {
       ).not.toBeInTheDocument()
     )
 
-    expect(dependent.requiredErrors()).toHaveLength(3)
+    expect(dependent.requiredErrors()).toHaveLength(2)
 
     userEvent.type(relationInput, '1111')
     userEvent.click(await dependent.saveButton())
@@ -489,7 +489,7 @@ describe('Dependents', () => {
       ).toHaveLength(1)
     )
 
-    expect(dependent.requiredErrors()).toHaveLength(2)
+    expect(dependent.requiredErrors()).toHaveLength(1)
 
     userEvent.type(relationInput, '{selectall}{del}stepchild')
     userEvent.click(await dependent.saveButton())
@@ -502,7 +502,7 @@ describe('Dependents', () => {
       ).not.toBeInTheDocument()
     )
 
-    expect(dependent.requiredErrors()).toHaveLength(2)
+    expect(dependent.requiredErrors()).toHaveLength(1)
 
     userEvent.type(birthYearInput, 'abcd')
     userEvent.click(await dependent.saveButton())


### PR DESCRIPTION
Add in Age and blindness status to the front end and the data model. I needed the date of birth for doing the California taxes (which asks for the date of birth for everyone) so I added in the date to the Person interface. This caused some complications though because AJV doesn't like Date objects so for the Information object I serialize to string. I tried to make Person a generic interface that could take a date or a string but that doesn't seem to work well when you extend a generic interface. 

I settled on enriching the `TaxPayer` class so that it would use the version with the `Date` object while the person interface in `Information` uses the string version. As part of this I also went through and used the `TaxPayer` class in many cases where there was a call to the `Information` object.

Not sure that this is the best way to handle this so would be open to other suggestions.

- Add the `TaxPayer` to form f1040
- clean up the constructors of many of the schedules as they were
  passing in redundant information or would construct new `TaxPayer`
  objects
- Remove unnecessary calls to create new `TaxPayer` objects when generating
  the fields of a form. In many cases this object was available
  already as part of f1040.
- Convert Dependent logic to use the `dateOfBirth` field and remove the `birthYear` field

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?**

- Feature
- Refactor

<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
