### PR TITLE
Fix Fica test is skipping 100% of the time

### DIFF
--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -60,6 +60,7 @@ const investmentResult = posNegCurrency(100000)
 const expense: Arbitrary<number> = posCurrency(10000)
 const interest: Arbitrary<number> = posCurrency(10000)
 const payment: Arbitrary<number> = fc.nat({ max: 100000 })
+const ssWitholding: Arbitrary<number> = fc.nat({ max: 10000 })
 
 const payerName: Arbitrary<string> = maxWords(3)
 
@@ -106,7 +107,7 @@ const w2: Arbitrary<types.IncomeW2> = wages.chain((income) =>
       fc.nat({ max: 2 * income }),
       fc.nat({ max: income }),
       fc.nat({ max: income }),
-      fc.nat({ max: income }),
+      ssWitholding,
       fc.nat({ max: income }),
       employer,
       w2Box12Info(income),

--- a/src/forms/Y2021/tests/fica.test.ts
+++ b/src/forms/Y2021/tests/fica.test.ts
@@ -8,6 +8,7 @@ import { claimableExcessSSTaxWithholding } from 'ustaxes/forms/Y2021/irsForms/Sc
 import { displayRound } from 'ustaxes/core/irsForms/util'
 import { testKit, commonTests } from '.'
 import { PersonRole } from 'ustaxes/core/data'
+import * as fc from 'fast-check'
 
 jest.setTimeout(100000)
 
@@ -92,6 +93,8 @@ describe('fica', () => {
             .reduce((l, r) => l + r, 0)
 
         expect(ssRefund).toEqual(ssWithheld - fica.maxSSTax)
+      } else {
+        fc.pre(false)
       }
       return Promise.resolve()
     })


### PR DESCRIPTION
Marking a filtered test with a pre-condition shows that this test is never actually being run.

We probably need to [change the arbitraries](https://github.com/ustaxes/UsTaxes/blob/master/src/core/tests/arbitraries.ts#L104) to generate values in the domain this property is supposed to be testing

@ctSkennerton can you take a look? 

```
 FAIL  src/forms/Y2021/tests/fica.test.ts (133.231 s)
  fica
    ✕ should give SS refund based on filing status (126134 ms)

  ● fica › should give SS refund based on filing status

    Failed to run property, too many pre-condition failures encountered
    { seed: -476405088 }

    Ran 0 time(s)
    Skipped 10001 time(s)

    Hint (1): Try to reduce the number of rejected values by combining map, flatMap and built-in arbitraries
    Hint (2): Increase failure tolerance by setting maxSkipsPerRun to an higher value
    Hint (3): Enable verbose mode at level VeryVerbose in order to check all generated values and their associated status

```

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix
