### PR TITLE
Fix bug caused by reset of form with {}

### DIFF
--- a/src/components/FormContainer.tsx
+++ b/src/components/FormContainer.tsx
@@ -14,7 +14,7 @@ import {
   Theme
 } from '@material-ui/core'
 import { Delete, Edit } from '@material-ui/icons'
-import { SubmitHandler, useFormContext } from 'react-hook-form'
+import { DefaultValues, SubmitHandler, useFormContext } from 'react-hook-form'
 import _ from 'lodash'
 import { ReactNode } from 'react'
 import { FormContainerProvider } from './FormContainer/Context'
@@ -133,6 +133,9 @@ interface FormListContainerProps<A> {
   onSubmitAdd: SubmitHandler<A>
   onSubmitEdit: (index: number) => SubmitHandler<A>
   onCancel?: () => void
+
+  // same default values passed to useForm
+  defaultValues: DefaultValues<A>
   items: A[]
   disableEditing?: boolean
   removeItem?: (v: number) => void
@@ -156,6 +159,7 @@ export interface OpenableFormContainerProps<A> {
   onCancel?: () => void
   onSave: SubmitHandler<A>
   isOpen?: boolean
+  defaultValues: DefaultValues<A>
   onOpenStateChange: (isOpen: boolean) => void
   allowAdd?: boolean
 }
@@ -164,7 +168,7 @@ export const OpenableFormContainer = <A,>(
   props: PropsWithChildren<OpenableFormContainerProps<A>>
 ): ReactElement => {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
-  const { isOpen = false, allowAdd = true } = props
+  const { isOpen = false, allowAdd = true, defaultValues } = props
   const classes = useStyles()
 
   // Note useFormContext here instead of useForm reuses the
@@ -177,7 +181,7 @@ export const OpenableFormContainer = <A,>(
 
   const closeForm = (): void => {
     props.onOpenStateChange(false)
-    reset({})
+    reset(defaultValues)
   }
 
   const onClose = (): void => {
@@ -235,6 +239,7 @@ const FormListContainer = <A,>(
     icon,
     max,
     primary,
+    defaultValues,
     secondary,
     disableEditing = false,
     removeItem,
@@ -271,7 +276,7 @@ const FormListContainer = <A,>(
   const closeForm = (): void => {
     setEditing(undefined)
     setOpen(false)
-    reset()
+    reset(defaultValues)
   }
 
   const cancel = (): void => {
@@ -335,6 +340,7 @@ const FormListContainer = <A,>(
       {itemDisplay}
       <OpenableFormContainer
         allowAdd={allowAdd}
+        defaultValues={defaultValues}
         onSave={onSave}
         isOpen={isOpen}
         onOpenStateChange={setOpen}

--- a/src/components/TaxPayer/SpouseAndDependent.tsx
+++ b/src/components/TaxPayer/SpouseAndDependent.tsx
@@ -109,10 +109,12 @@ export const AddDependentForm = (): ReactElement => {
     (state: TaxesState) => state.information.taxPayer.dependents
   )
 
+  const defaultValues = blankUserDependentForm
+
   const dispatch = useDispatch()
 
   const methods = useForm<UserDependentForm>({
-    defaultValues: blankUserDependentForm
+    defaultValues
   })
 
   const onSubmitAdd = (formData: UserDependentForm): void => {
@@ -127,6 +129,7 @@ export const AddDependentForm = (): ReactElement => {
 
   const page = (
     <FormListContainer<UserDependentForm>
+      defaultValues={defaultValues}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}
       items={dependents.map((a) => toDependentForm(a))}
@@ -164,8 +167,9 @@ export const AddDependentForm = (): ReactElement => {
 }
 
 export const SpouseInfo = (): ReactElement => {
+  const defaultValues = blankUserSpouseForm
   const methods = useForm<UserSpouseForm>({
-    defaultValues: blankUserSpouseForm
+    defaultValues
   })
   const { getValues } = methods
   const dispatch = useDispatch()
@@ -182,6 +186,7 @@ export const SpouseInfo = (): ReactElement => {
 
   const page = (
     <FormListContainer
+      defaultValues={defaultValues}
       items={spouse !== undefined ? [toSpouseForm(spouse)] : []}
       primary={(s) => `${s.firstName} ${s.lastName}`}
       secondary={(s) => formatSSID(s.ssid)}

--- a/src/components/Y2021/AdvanceChildTaxCredit.tsx
+++ b/src/components/Y2021/AdvanceChildTaxCredit.tsx
@@ -36,6 +36,7 @@ const toCreditUserInput = (c: Credit): CreditUserInput => {
 }
 
 export const AdvanceChildTaxCredit = (): ReactElement => {
+  const defaultValues = blankCreditUserInput
   const credits = useSelector(({ information }) => information.credits)
   const taxPayer = useSelector(({ information }) => information.taxPayer)
   const spouse = taxPayer.spouse
@@ -58,7 +59,7 @@ export const AdvanceChildTaxCredit = (): ReactElement => {
   const dispatch = useDispatch()
 
   const methods = useForm<CreditUserInput>({
-    defaultValues: blankCreditUserInput
+    defaultValues
   })
 
   const onSubmitAdd = (formData: CreditUserInput): void => {
@@ -84,6 +85,7 @@ export const AdvanceChildTaxCredit = (): ReactElement => {
         indicated on Letter 6419.
       </p>
       <FormListContainer<CreditUserInput>
+        defaultValues={defaultValues}
         primary={(c) =>
           c.recipient === PersonRole.PRIMARY ? primaryName : spouseName
         }

--- a/src/components/deductions/F1098eInfo.tsx
+++ b/src/components/deductions/F1098eInfo.tsx
@@ -63,6 +63,7 @@ export default function F1098eInfo(): ReactElement {
 
   const form: ReactElement | undefined = (
     <FormListContainer
+      defaultValues={defaultValues}
       onSubmitAdd={onAdd1098e}
       onSubmitEdit={onEdit1098e}
       items={f1098es.map((a) => toUserInput(a))}

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -227,7 +227,9 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
 export default function F1099Info(): ReactElement {
   const f1099s = useSelector((state: TaxesState) => state.information.f1099s)
 
-  const methods = useForm<F1099UserInput>()
+  const defaultValues = blankUserInput
+
+  const methods = useForm<F1099UserInput>({ defaultValues })
   const { handleSubmit, watch } = methods
   const selectedType: Income1099Type | undefined = watch('formType')
 
@@ -411,6 +413,7 @@ export default function F1099Info(): ReactElement {
 
   const form: ReactElement | undefined = (
     <FormListContainer
+      defaultValues={defaultValues}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}
       items={f1099s.map((a) => toUserInput(a))}

--- a/src/components/income/F1099Info.tsx
+++ b/src/components/income/F1099Info.tsx
@@ -90,7 +90,7 @@ interface F1099UserInput {
   dividends: string | number
   qualifiedDividends: string | number
   totalCapitalGainsDistributions: string | number
-  personRole: PersonRole.PRIMARY | PersonRole.SPOUSE
+  personRole?: PersonRole.PRIMARY | PersonRole.SPOUSE
   // R fields
   grossDistribution: string | number
   taxableAmount: string | number
@@ -105,7 +105,6 @@ interface F1099UserInput {
 const blankUserInput: F1099UserInput = {
   formType: undefined,
   payer: '',
-  personRole: PersonRole.PRIMARY,
   interest: '',
   // B Fields
   shortTermProceeds: '',
@@ -161,7 +160,7 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
     case Income1099Type.INT: {
       return {
         payer: input.payer,
-        personRole: input.personRole,
+        personRole: input.personRole ?? PersonRole.PRIMARY,
         type: input.formType,
         form: {
           income: Number(input.interest)
@@ -171,7 +170,7 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
     case Income1099Type.B: {
       return {
         payer: input.payer,
-        personRole: input.personRole,
+        personRole: input.personRole ?? PersonRole.PRIMARY,
         type: input.formType,
         form: {
           shortTermCostBasis: Number(input.shortTermCostBasis),
@@ -184,7 +183,7 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
     case Income1099Type.DIV: {
       return {
         payer: input.payer,
-        personRole: input.personRole,
+        personRole: input.personRole ?? PersonRole.PRIMARY,
         type: input.formType,
         form: {
           dividends: Number(input.dividends),
@@ -198,7 +197,7 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
     case Income1099Type.R: {
       return {
         payer: input.payer,
-        personRole: input.personRole,
+        personRole: input.personRole ?? PersonRole.PRIMARY,
         type: input.formType,
         form: {
           grossDistribution: Number(input.grossDistribution),
@@ -211,7 +210,7 @@ const toF1099 = (input: F1099UserInput): Supported1099 | undefined => {
     case Income1099Type.SSA: {
       return {
         payer: input.payer,
-        personRole: input.personRole,
+        personRole: input.personRole ?? PersonRole.PRIMARY,
         type: input.formType,
         form: {
           // benefitsPaid: Number(input.benefitsPaid),

--- a/src/components/income/OtherInvestments.tsx
+++ b/src/components/income/OtherInvestments.tsx
@@ -42,6 +42,15 @@ interface AssetUserInput {
   state?: State
 }
 
+const blankAssetUserInput: AssetUserInput = {
+  name: '',
+  positionType: 'Security',
+  openPrice: '',
+  openFee: '',
+  closeFee: '',
+  quantity: ''
+}
+
 const toAsset = (input: AssetUserInput): Asset<Date> | undefined => {
   const {
     name,
@@ -75,7 +84,8 @@ const toAsset = (input: AssetUserInput): Asset<Date> | undefined => {
 export const OtherInvestments = (): ReactElement => {
   const year = useSelector((state: YearsTaxesState) => state.activeYear)
   const [isOpen, setOpen] = useState(false)
-  const methods = useForm<AssetUserInput>()
+  const defaultValues = blankAssetUserInput
+  const methods = useForm<AssetUserInput>({ defaultValues })
   const { handleSubmit, watch } = methods
   const positionType = watch('positionType')
   const closeDate = watch('closeDate')
@@ -92,6 +102,7 @@ export const OtherInvestments = (): ReactElement => {
 
   const form: ReactElement | undefined = (
     <OpenableFormContainer
+      defaultValues={defaultValues}
       isOpen={isOpen}
       onOpenStateChange={setOpen}
       onSave={onSubmitAdd}

--- a/src/components/income/PartnershipIncome.tsx
+++ b/src/components/income/PartnershipIncome.tsx
@@ -150,7 +150,9 @@ export const PartnershipIncome = (): ReactElement => {
     p !== undefined ? [p as Person] : []
   )
 
-  const methods = useForm<ScheduleK1Form1065UserInput>()
+  const defaultValues = blankUserInput
+
+  const methods = useForm<ScheduleK1Form1065UserInput>({ defaultValues })
   const { handleSubmit } = methods
   const dispatch = useDispatch()
 
@@ -174,6 +176,7 @@ export const PartnershipIncome = (): ReactElement => {
 
   const form: ReactElement | undefined = (
     <FormListContainer<ScheduleK1Form1065UserInput>
+      defaultValues={defaultValues}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}
       items={ScheduleK1Form1065s.map((a) => toUserInput(a))}

--- a/src/components/income/RealEstate.tsx
+++ b/src/components/income/RealEstate.tsx
@@ -140,7 +140,8 @@ const toUserInput = (property: Property): PropertyAddForm => {
 }
 
 export default function RealEstate(): ReactElement {
-  const methods = useForm<PropertyAddForm>({ defaultValues: blankAddForm })
+  const defaultValues = blankAddForm
+  const methods = useForm<PropertyAddForm>({ defaultValues })
   const { handleSubmit, control, getValues } = methods
 
   const dispatch = useDispatch()
@@ -217,6 +218,7 @@ export default function RealEstate(): ReactElement {
 
   const form = (
     <FormListContainer
+      defaultValues={defaultValues}
       items={properties.map((a) => toUserInput(a))}
       icon={() => <HouseOutlined />}
       primary={(p) => toProperty(p).address.address}

--- a/src/components/income/StockOptions.tsx
+++ b/src/components/income/StockOptions.tsx
@@ -66,6 +66,7 @@ const toF3921 = (input: F3921UserInput): F3921 | undefined => {
 }
 
 export const StockOptions = (): ReactElement => {
+  const defaultValues = blankUserInput
   const information: Information = useSelector(
     (state: TaxesState) => state.information
   )
@@ -86,7 +87,7 @@ export const StockOptions = (): ReactElement => {
     p !== undefined ? [p as Person] : []
   )
 
-  const methods = useForm<F3921UserInput>()
+  const methods = useForm<F3921UserInput>({ defaultValues })
   const { handleSubmit } = methods
   const dispatch = useDispatch()
 
@@ -110,6 +111,7 @@ export const StockOptions = (): ReactElement => {
 
   const form: ReactElement | undefined = (
     <FormListContainer<F3921UserInput>
+      defaultValues={defaultValues}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}
       items={f3921s.map((a) => toUserInput(a))}

--- a/src/components/income/W2JobInfo.tsx
+++ b/src/components/income/W2JobInfo.tsx
@@ -165,9 +165,9 @@ const Box12Data = (): ReactElement => {
 
 export default function W2JobInfo(): ReactElement {
   const dispatch = useDispatch()
-
+  const defaultValues = blankW2UserInput
   const methods = useForm<IncomeW2UserInput>({
-    defaultValues: blankW2UserInput
+    defaultValues
   })
 
   const { navButtons, onAdvance } = usePager()
@@ -203,6 +203,7 @@ export default function W2JobInfo(): ReactElement {
 
   const w2sBlock = (
     <FormListContainer<IncomeW2UserInput>
+      defaultValues={defaultValues}
       items={w2s.map((a) => toIncomeW2UserInput(a))}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}

--- a/src/components/input/LabeledCheckbox.tsx
+++ b/src/components/input/LabeledCheckbox.tsx
@@ -34,7 +34,7 @@ export function LabeledCheckbox<TFormValues>(
                 control={
                   <Checkbox
                     name={name}
-                    checked={(value as boolean | undefined) ?? false}
+                    checked={value as boolean}
                     onChange={(_, checked) => onChange(checked)}
                     color="primary"
                   />

--- a/src/components/payments/EstimatedTaxes.tsx
+++ b/src/components/payments/EstimatedTaxes.tsx
@@ -48,6 +48,7 @@ const toEstimatedTaxesUserInput = (
 })
 
 export default function EstimatedTaxes(): ReactElement {
+  const defaultValues = blankUserInput
   const activeYear: TaxYear = useSelector(
     (state: YearsTaxesState) => state.activeYear
   )
@@ -58,7 +59,7 @@ export default function EstimatedTaxes(): ReactElement {
 
   const dispatch = useDispatch()
 
-  const methods = useForm<EstimatedTaxesUserInput>()
+  const methods = useForm<EstimatedTaxesUserInput>({ defaultValues })
 
   const { navButtons, onAdvance } = usePager()
 
@@ -74,6 +75,7 @@ export default function EstimatedTaxes(): ReactElement {
 
   const w2sBlock = (
     <FormListContainer<EstimatedTaxesUserInput>
+      defaultValues={defaultValues}
       items={estimatedTaxes.map((a) => toEstimatedTaxesUserInput(a))}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}

--- a/src/components/savingsAccounts/IRA.tsx
+++ b/src/components/savingsAccounts/IRA.tsx
@@ -107,6 +107,7 @@ const toIraUserInput = (data: Ira): IraUserInput => ({
 })
 
 export default function IRA(): ReactElement {
+  const defaultValues = blankUserInput
   const ira = useYearSelector(
     (state: TaxesState) => state.information.individualRetirementArrangements
   )
@@ -120,7 +121,7 @@ export default function IRA(): ReactElement {
 
   const dispatch = useYearDispatch()
 
-  const methods = useForm<IraUserInput>()
+  const methods = useForm<IraUserInput>({ defaultValues })
   const { handleSubmit } = methods
 
   const { navButtons, onAdvance } = usePager()
@@ -137,6 +138,7 @@ export default function IRA(): ReactElement {
 
   const hsaBlock = (
     <FormListContainer<IraUserInput>
+      defaultValues={defaultValues}
       items={ira.map((a) => toIraUserInput(a))}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}

--- a/src/components/savingsAccounts/healthSavingsAccounts.tsx
+++ b/src/components/savingsAccounts/healthSavingsAccounts.tsx
@@ -80,6 +80,7 @@ const toHSAUserInput = (data: HealthSavingsAccount): HSAUserInput => ({
 })
 
 export default function HealthSavingsAccounts(): ReactElement {
+  const defaultValues = blankUserInput
   const hsa = useYearSelector(
     (state: TaxesState) => state.information.healthSavingsAccounts
   )
@@ -93,7 +94,7 @@ export default function HealthSavingsAccounts(): ReactElement {
 
   const dispatch = useYearDispatch()
 
-  const methods = useForm<HSAUserInput>()
+  const methods = useForm<HSAUserInput>({ defaultValues })
   const { handleSubmit } = methods
 
   const activeYear: TaxYear = useSelector(
@@ -114,6 +115,7 @@ export default function HealthSavingsAccounts(): ReactElement {
 
   const hsaBlock = (
     <FormListContainer<HSAUserInput>
+      defaultValues={defaultValues}
       items={hsa.map((a) => toHSAUserInput(a))}
       onSubmitAdd={onSubmitAdd}
       onSubmitEdit={onSubmitEdit}


### PR DESCRIPTION
When using an open/closable form, such as for dependents, W2s, 1099s, etc, after the form is submitted the first time, or the form is opened and then closed, on reopening the form will fail if there is a checkbox on the form and the checkbox is not selected on a subsequent use.

This is caused by the form being initialized with an object of default values including `{checkboxValue: false}`, and then reset with `{}`, so `checkboxValue` is `undefined` and submitted in the action undefined while it is required. Our AJV validation catches this and prevents the object with missing properties from being created in the redux store.

[Note this doc suggests that if reset is called then all the properties should be supplied](https://react-hook-form.com/api/useform/reset/), or the html form reset api is used. HTML reset api is not useful for us because the form container may be used without a `<form>` tag. Unfortunately `react-hook-form` doesn't make the `defaultValues` the form was created with accessible in context, so we have to create a new property to pass to `FormListContainer`.
 


**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix
