### PR TITLE
Fix save to file / load from file date handling

### DIFF
--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -1,9 +1,8 @@
 import { Check } from '@material-ui/icons'
 import { ReactElement, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { Load } from 'ustaxes/redux/fs'
 import { fsRecover } from 'ustaxes/redux/fs/Actions'
-import { USTSerializedState } from 'ustaxes/redux/store'
+import { LoadRaw } from 'ustaxes/redux/fs/Load'
 import SaveToFile from './SaveToFile'
 
 const UserSettings = (): ReactElement => {
@@ -23,7 +22,7 @@ const UserSettings = (): ReactElement => {
         Load your saved data from a file. Warning, this will overwrite present
         state.
       </p>
-      <Load<USTSerializedState>
+      <LoadRaw
         startIcon={done ? <Check /> : undefined}
         accept="*.json"
         handleData={(state) => {
@@ -36,7 +35,7 @@ const UserSettings = (): ReactElement => {
         color="primary"
       >
         Load
-      </Load>
+      </LoadRaw>
     </>
   )
 }

--- a/src/core/tests/arbitraries.ts
+++ b/src/core/tests/arbitraries.ts
@@ -9,6 +9,7 @@ import {
   ValidatedInformation,
   ValidatedTaxpayer
 } from 'ustaxes/forms/F1040Base'
+import { blankYearTaxesState, YearsTaxesState } from 'ustaxes/redux'
 
 const lower: Arbitrary<string> = fc
   .integer({ min: 0x61, max: 0x7a })
@@ -698,3 +699,30 @@ export class Arbitraries {
 }
 
 export const forYear = (year: number): Arbitraries => new Arbitraries(year)
+
+export const asset: Arbitrary<types.Asset> = fc
+  .tuple(
+    fc.string(),
+    fc.constantFrom<types.AssetType>('Security', 'Real Estate'),
+    fc.date(),
+    fc.nat({ max: 100000 }),
+    fc.nat({ max: 100 }),
+    fc.nat({ max: 100 })
+  )
+  .map(([name, positionType, openDate, openPrice, openFee, quantity]) => ({
+    name,
+    positionType,
+    openPrice,
+    openDate,
+    openFee,
+    quantity
+  }))
+
+export const yearsTaxesState: Arbitrary<YearsTaxesState> = fc
+  .tuple(forYear(2021).information(), fc.array(asset))
+  .map(([Y2021, assets]) => ({
+    ...blankYearTaxesState,
+    Y2021,
+    assets,
+    activeYear: 'Y2021'
+  }))

--- a/src/redux/fs/Actions.ts
+++ b/src/redux/fs/Actions.ts
@@ -8,16 +8,16 @@ export interface FSPersist extends FSAction {
   readonly type: 'fs/persist'
 }
 
-export interface FSRecover<S> extends FSAction {
+export interface FSRecover extends FSAction {
   readonly type: 'fs/recover'
-  data: S
+  data: string
 }
 
 export const fsPersist = (): FSPersist => ({
   type: 'fs/persist'
 })
 
-export const fsRecover = <S>(data: S): FSRecover<S> => ({
+export const fsRecover = (data: string): FSRecover => ({
   type: 'fs/recover',
   data
 })

--- a/src/redux/fs/FSReducer.ts
+++ b/src/redux/fs/FSReducer.ts
@@ -1,15 +1,9 @@
 import { AnyAction, Reducer } from 'redux'
-import { download } from '.'
-import {
-  deserializeTransform,
-  migrate,
-  serializeTransform,
-  USTSerializedState,
-  USTState
-} from '../store'
+import { download, stateToString, stringToState } from '.'
+import { migrate, USTState } from '../store'
 import { FSPersist, FSRecover } from './Actions'
 
-type PersistActions = FSPersist | FSRecover<USTSerializedState>
+type PersistActions = FSPersist | FSRecover
 
 /**
  * Extends a reducer to persist and load data
@@ -19,7 +13,7 @@ type PersistActions = FSPersist | FSRecover<USTSerializedState>
  * It will overwrite whatever state exists with whatever
  * state it finds, but needs none of its own state.
  */
-const fsReducer = <S extends USTState, A extends AnyAction>(
+export const fsReducer = <S extends USTState, A extends AnyAction>(
   filename: string,
   reducer: Reducer<S, A>
 ): Reducer<S, A & PersistActions> => {
@@ -34,12 +28,12 @@ const fsReducer = <S extends USTState, A extends AnyAction>(
           ...newState,
           ...migrate(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            deserializeTransform((action as FSRecover<USTSerializedState>).data)
+            stringToState(action.data)
           )
         }
       }
       case 'fs/persist': {
-        download(filename, JSON.stringify(serializeTransform(newState)))
+        download(filename, stateToString(newState))
         return newState
       }
       default: {
@@ -48,5 +42,3 @@ const fsReducer = <S extends USTState, A extends AnyAction>(
     }
   }
 }
-
-export default fsReducer

--- a/src/redux/fs/index.ts
+++ b/src/redux/fs/index.ts
@@ -7,8 +7,21 @@ import Load from './Load'
 export const stateToString = (state: any): string =>
   JSON.stringify(serializeTransform(state))
 
-export const stringToState = (str: string): USTState =>
-  deserializeTransform(JSON.parse(str)) as USTState
+/**
+ * Reuse the same functionality as reloading the state from redux-persist,
+ * to reload state from a file
+ */
+export const stringToState = (str: string): USTState => {
+  const data = JSON.parse(str) as Record<string, unknown>
+  return Object.keys(data).reduce(
+    (acc, key) => ({
+      ...acc,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      [key]: deserializeTransform(data[key])
+    }),
+    {}
+  ) as USTState
+}
 
 export const download = (filename: string, text: string): void => {
   const element = document.createElement('a')

--- a/src/redux/fs/index.ts
+++ b/src/redux/fs/index.ts
@@ -1,8 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { deserializeTransform, serializeTransform, USTState } from '../store'
 import Load from './Load'
 
-const download = (filename: string, text: string): void => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+export const stateToString = (state: any): string =>
+  JSON.stringify(serializeTransform(state))
+
+export const stringToState = (str: string): USTState =>
+  deserializeTransform(JSON.parse(str)) as USTState
+
+export const download = (filename: string, text: string): void => {
   const element = document.createElement('a')
   element.setAttribute(
     'href',
@@ -18,7 +26,7 @@ const download = (filename: string, text: string): void => {
   document.body.removeChild(element)
 }
 
-const loadFile = async (file: File): Promise<string> => {
+export const loadFile = async (file: File): Promise<string> => {
   const fileReader: FileReader = new FileReader()
 
   return new Promise((resolve, reject) => {
@@ -39,4 +47,4 @@ const loadFile = async (file: File): Promise<string> => {
   })
 }
 
-export { download, loadFile, Load }
+export { Load }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -15,7 +15,7 @@ import { Actions } from './actions'
 import { PersistPartial } from 'redux-persist/es/persistReducer'
 import { createTransform } from 'redux-persist'
 import { FSAction } from './fs/Actions'
-import fsReducer from './fs/FSReducer'
+import { fsReducer } from './fs/FSReducer'
 import { migrateEachYear } from './migration'
 import _ from 'lodash'
 

--- a/src/tests/Recover.test.ts
+++ b/src/tests/Recover.test.ts
@@ -1,0 +1,13 @@
+import * as fc from 'fast-check'
+import * as arbitraries from 'ustaxes/core/tests/arbitraries'
+import { stateToString, stringToState } from 'ustaxes/redux/fs'
+
+describe('FS Recover / Save', () => {
+  it('should restore the same data it created', () => {
+    fc.assert(
+      fc.property(arbitraries.yearsTaxesState, (state) => {
+        expect(stringToState(stateToString(state))).toEqual(state)
+      })
+    )
+  })
+})


### PR DESCRIPTION
Dates were not being converted to / from string properly when saving a file to json.

Adds a failing test that asserts any arbitrary state should be saved and loaded properly.


**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

