### PR TITLE
Add Support page and data anonymizer

### DIFF
--- a/src/components/HelpAndFeedback.tsx
+++ b/src/components/HelpAndFeedback.tsx
@@ -1,0 +1,74 @@
+import { Button, Grid, TextField } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
+import { ReactElement, useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { intentionallyFloat } from 'ustaxes/core/util'
+import { USTState } from 'ustaxes/redux/store'
+import anonymize from '../core/data/anonymize'
+
+const HelpAndFeedback = (): ReactElement => {
+  const state = useSelector((state: USTState) => state)
+  const [anonymizedState, setAnonymizedState] = useState('')
+  const [copied, doSetCopied] = useState(false)
+
+  useEffect(() => {
+    setAnonymizedState(JSON.stringify(anonymize(state), undefined, 2))
+  }, [state])
+
+  const setCopied = (): void => {
+    doSetCopied(true)
+    setTimeout(() => doSetCopied(false), 5000)
+  }
+
+  const copiedAlert = (() => {
+    if (copied) {
+      return (
+        <Grid item>
+          <Alert severity="info">Copied to clipboard</Alert>
+        </Grid>
+      )
+    }
+  })()
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(anonymizedState)
+    setCopied()
+  }
+
+  return (
+    <>
+      <h2>Help and Feedback</h2>
+      <p>Did you notice something wrong?</p>
+      <p>
+        Please email <strong>feedback@ustaxes.org</strong> with any questions or
+        bugs. If your personal data might be helpful, please copy paste the
+        below into the body of the email. Your data below should be properly
+        anonymized.
+      </p>
+      <Grid container spacing={2} direction="column">
+        <Grid item>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={intentionallyFloat(copyToClipboard)}
+          >
+            Copy to clipboard
+          </Button>
+        </Grid>
+        {copiedAlert}
+        <Grid item>
+          <TextField
+            disabled
+            multiline
+            minRows={40}
+            maxRows={100}
+            fullWidth
+            value={JSON.stringify(anonymize(state), null, 2)}
+          />
+        </Grid>
+      </Grid>{' '}
+    </>
+  )
+}
+
+export default HelpAndFeedback

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -32,6 +32,7 @@ import GettingStarted from './GettingStarted'
 import F1098eInfo from './deductions/F1098eInfo'
 import ItemizedDeductions from './deductions/ItemizedDeductions'
 import Questions from './Questions'
+import HelpAndFeedback from './HelpAndFeedback'
 import UserSettings from './UserSettings'
 import Urls from 'ustaxes/data/urls'
 
@@ -94,6 +95,11 @@ export const backPages: SectionItem[] = [
     title: 'User Settings',
     url: Urls.settings,
     element: <UserSettings />
+  },
+  {
+    title: 'Help and Feedback',
+    url: Urls.help,
+    element: <HelpAndFeedback />
   }
 ]
 

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -16,7 +16,7 @@ import {
 } from '@material-ui/core'
 import GitHubIcon from '@material-ui/icons/GitHub'
 import TwitterIcon from '@material-ui/icons/Twitter'
-import { Settings } from '@material-ui/icons'
+import { HelpOutlineRounded, Settings } from '@material-ui/icons'
 import Urls from 'ustaxes/data/urls'
 
 const drawerWidth = 240
@@ -128,6 +128,11 @@ function ResponsiveDrawer(props: DrawerItemsProps): ReactElement {
       ))}
       <List className={classes.listSocial}>
         <ListItem className={classes.listItemSocial}>
+          <Link to={Urls.help}>
+            <IconButton color="secondary" aria-label="help, support, feedback">
+              <HelpOutlineRounded />
+            </IconButton>
+          </Link>
           <IconButton
             color="secondary"
             aria-label="github, opens in new tab"

--- a/src/core/data/anonymize.ts
+++ b/src/core/data/anonymize.ts
@@ -1,0 +1,152 @@
+import { YearsTaxesState } from 'ustaxes/redux'
+import {
+  F3921,
+  Ira,
+  Supported1099,
+  Dependent,
+  Employer,
+  F1098e,
+  Information,
+  Person,
+  PersonRole,
+  TaxPayer,
+  Address,
+  IncomeW2,
+  Property,
+  ScheduleK1Form1065
+} from '.'
+
+const anonymizePerson = (person: Person): Person => {
+  const roles = [
+    PersonRole.PRIMARY,
+    PersonRole.SPOUSE,
+    PersonRole.DEPENDENT,
+    PersonRole.EMPLOYER
+  ]
+
+  return {
+    ...person,
+    ssid: `${100000000 + roles.findIndex((r) => r === person.role)}`,
+    firstName: `${person.role}first`,
+    lastName: `${person.role}last`
+  }
+}
+
+const anonymizeDependent = (dependent: Dependent, idx: number): Dependent => {
+  return {
+    ...dependent,
+    ...anonymizePerson(dependent),
+    ssid: `${200000000 + idx}`,
+    firstName: `dependent-${idx}-first`,
+    lastName: `dependent-${idx}-first`
+  }
+}
+
+const anonymizeAddress = (address: Address, prefix = ''): Address => ({
+  ...address,
+  address: `${prefix} address`,
+  city: `${prefix} city`,
+  aptNo: address.aptNo !== undefined ? `${prefix} apt` : undefined,
+  zip: address.zip !== undefined ? '99999' : undefined,
+  foreignCountry:
+    address.foreignCountry === undefined
+      ? undefined
+      : `${prefix} foreign country`,
+  postalCode: address.postalCode !== undefined ? `${prefix} postal` : undefined,
+  province: address.province !== undefined ? `${prefix} province` : undefined
+})
+
+const anonymizeEmployer = (employer: Employer): Employer => ({
+  ...employer,
+  EIN: '999999999',
+  employerName: 'anonymous employer',
+  address:
+    employer.address === undefined
+      ? undefined
+      : anonymizeAddress(employer.address, 'employer')
+})
+
+const anonymizeF1098e = (f: F1098e): F1098e => ({
+  ...f,
+  lender: 'lender'
+})
+
+const anonymizeF1099 = (f: Supported1099, idx: number): Supported1099 => ({
+  ...f,
+  payer: `payer ${idx}`
+})
+
+const anonymizeF3921 = (f: F3921, idx: number): F3921 => ({
+  ...f,
+  name: `3921 name ${idx}`
+})
+
+const anonymizeIra = (ira: Ira, idx: number): Ira => ({
+  ...ira,
+  payer: `ira payer ${idx}`
+})
+
+const anonymizeTaxPayer = (tp: TaxPayer): TaxPayer => ({
+  ...tp,
+  contactEmail: tp.contactEmail === undefined ? undefined : 'a@b.com',
+  contactPhoneNumber:
+    tp.contactPhoneNumber === undefined ? undefined : '1234567890',
+  dependents: tp.dependents.map(anonymizeDependent),
+  primaryPerson:
+    tp.primaryPerson === undefined
+      ? undefined
+      : { ...tp.primaryPerson, ...anonymizePerson(tp.primaryPerson) },
+  spouse:
+    tp.spouse === undefined
+      ? undefined
+      : { ...tp.spouse, ...anonymizePerson(tp.spouse) }
+})
+
+const anonymizeW2 = (w2: IncomeW2): IncomeW2 => ({
+  ...w2,
+  employer:
+    w2.employer === undefined ? undefined : anonymizeEmployer(w2.employer),
+  occupation: 'occupation'
+})
+
+const anonymizeRealEstate = (realEstate: Property): Property => ({
+  ...realEstate,
+  address: anonymizeAddress(realEstate.address, 'property')
+})
+
+const anonymizeK1 = (
+  k1: ScheduleK1Form1065,
+  idx: number
+): ScheduleK1Form1065 => ({
+  ...k1,
+  partnershipName: `partnership ${idx}`,
+  partnershipEin: '888888888'
+})
+
+export const anonymizeInformation = (info: Information): Information => ({
+  ...info,
+  f1098es: info.f1098es.map(anonymizeF1098e),
+  f1099s: info.f1099s.map(anonymizeF1099),
+  f3921s: info.f3921s.map(anonymizeF3921),
+  individualRetirementArrangements:
+    info.individualRetirementArrangements.map(anonymizeIra),
+  refund:
+    info.refund === undefined
+      ? undefined
+      : {
+          ...info.refund,
+          accountNumber: '123456789',
+          routingNumber: '123456789'
+        },
+  taxPayer: anonymizeTaxPayer(info.taxPayer),
+  w2s: info.w2s.map(anonymizeW2),
+  realEstate: info.realEstate.map(anonymizeRealEstate),
+  scheduleK1Form1065s: info.scheduleK1Form1065s.map(anonymizeK1)
+})
+
+export default (input: YearsTaxesState): YearsTaxesState => ({
+  ...input,
+  Y2019: anonymizeInformation(input.Y2019),
+  Y2020: anonymizeInformation(input.Y2020),
+  Y2021: anonymizeInformation(input.Y2021)
+})

--- a/src/data/urls.ts
+++ b/src/data/urls.ts
@@ -34,6 +34,7 @@ const Urls = {
   },
   createPdf: '/createpdf',
   settings: '/settings',
+  help: '/help',
   Y2021: {
     credits: `/Y2021/credits`
   },


### PR DESCRIPTION
Adds a new page for the user to submit feedback or bug reports. 

Allows the user to copy paste anonymized data, where all names, addresses, SSN, EIN, account numbers, etc are removed.

![image](https://user-images.githubusercontent.com/1987109/165884303-6ed71075-ff20-4e44-b9d9-1a3425507b9b.png)



**What kind of change does this PR introduce?** 
- Feature
