### PR TITLE
Run docker-compose on windows 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,6 @@ ADD ./scripts ./scripts
 RUN npm ci
 
 ADD . .
+USER root
+RUN chown -R node /home/node/app
+USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,3 @@ services:
     command: npm run start
     ports:
       - '3000:3000'
-    volumes:
-      - ./:/app


### PR DESCRIPTION
Fixes #1061

- Don't bind mount to app in the docker-compose file
- chown /home/node/app dir for node user inside of the Dockerfile as a final step to ensure proper ownership


**What kind of change does this PR introduce?** 
- Bugfix



