### PR TITLE
Y2022: 8812: fix the 12yes/no error issue

### DIFF
--- a/src/forms/Y2022/irsForms/Schedule8812.ts
+++ b/src/forms/Y2022/irsForms/Schedule8812.ts
@@ -81,8 +81,8 @@ export default class Schedule8812 extends F1040Attachment {
   l11 = (): number => this.l10() * 0.05
 
   l12 = (): number => Math.max(0, this.l8() - this.l11())
-  l12no = (): boolean => this.l8() > this.l11()
-  l12yes = (): boolean => !this.l12no()
+  l12yes = (): boolean => this.l8() > this.l11()
+  l12no = (): boolean => !this.l12yes()
   // you and spouse have residence in US for more than half of year.
   // TODO: Assuming true
   l13 = (): number => this.creditLimitWorksheetA()


### PR DESCRIPTION
Fixes #1717 
The line 12yes/no logic is opposite, which will eventually lead to the credit error, here fix it.
