### PR TITLE
Fix node 20 issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51-slim-buster
+FROM rust:1.76-slim-bookworm
 
 RUN mkdir -p /home/node/app
 
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y curl
 USER node
 # Install nvm, node, npm
 ARG NVM_DIR="/home/node/.nvm"
-ARG NODE_VERSION=16.7.0
+ARG NODE_VERSION=20.10.0
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh | bash
 RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION --latest-npm
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ This application can be run as either a web application or a [standalone desktop
 
 ### Web application
 
-This project runs on Node 16. To ensure you're on the proper version, we recommend [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
+This project runs on Node 20. To ensure you're on the proper version, we recommend [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
 
 With `nvm` installed, you may select a version 16 node using:
 
 ```sh
-nvm install 16
-nvm use 16
+nvm install 20
+nvm use 20
 ```
 
 To run,
@@ -113,8 +113,8 @@ export NVM_DIR="$HOME/.nvm"
 . "$NVM_DIR/nvm.sh"  # This loads nvm
 #. "$NVM_DIR/bash_completion"  # Optional, nvm bash completion
 
-nvm install 16
-nvm use 16
+nvm install 20
+nvm use 20
 ```
 
 your environment will be set up every time you enter the project directory.

--- a/src/redux/fs/Load.tsx
+++ b/src/redux/fs/Load.tsx
@@ -1,7 +1,6 @@
 import { Button, ButtonProps } from '@material-ui/core'
 import { ChangeEvent, PropsWithChildren, ReactElement } from 'react'
 import { intentionallyFloat } from 'ustaxes/core/util'
-import { loadFile } from '.'
 
 interface LoadProps<S> {
   handleData: (s: S) => void
@@ -9,6 +8,27 @@ interface LoadProps<S> {
 
 interface Accept {
   accept?: string
+}
+
+export const loadFile = async (file: File): Promise<string> => {
+  const fileReader: FileReader = new FileReader()
+
+  return new Promise((resolve, reject) => {
+    fileReader.onload = function (
+      this: FileReader,
+      e: ProgressEvent<FileReader>
+    ): void {
+      e.preventDefault()
+      // type known here because of readAsText
+      const contents: string | null = fileReader.result as string | null
+      if (contents === null) {
+        reject('file contents were null')
+      } else {
+        resolve(contents)
+      }
+    }
+    fileReader.readAsText(file)
+  })
 }
 
 export const LoadRaw = (

--- a/src/redux/fs/index.ts
+++ b/src/redux/fs/index.ts
@@ -30,25 +30,4 @@ export const download = (filename: string, text: string): void => {
   document.body.removeChild(element)
 }
 
-export const loadFile = async (file: File): Promise<string> => {
-  const fileReader: FileReader = new FileReader()
-
-  return new Promise((resolve, reject) => {
-    fileReader.onload = function (
-      this: FileReader,
-      e: ProgressEvent<FileReader>
-    ): any {
-      e.preventDefault()
-      // type known here because of readAsText
-      const contents: string | null = fileReader.result as string | null
-      if (contents === null) {
-        reject('file contents were null')
-      } else {
-        resolve(contents)
-      }
-    }
-    fileReader.readAsText(file)
-  })
-}
-
 export { Load }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix
- Docs

This fixes issues in getting the webapp to run due to a cyclical dependency. Specifically, the error message that may appear on the screen is the following:

```
Uncaught ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization
```

This is because of a cyclical dependency between `src/redux/fs/Load.tsx` and `src/redux/fs/index.ts`. This was determined by opening developer tools, looking at the javascript source to see where the error was being printed from, seeing that it was from `src/redux/fs/Load.tsx`, and checking to see what files were being imported. Additionally, during this time, I modified eslint to check for `import/no-cycles`, which brought up many errors alongside this one, and made it easier to pinpoint the error.

Additionally, update the docs and Dockerfile to use Node 20 and Bookworm.

Fixes #2031

<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
