### PR TITLE
Fix investments after January 31, 2022 not being able to be entered

### DIFF
--- a/src/components/income/OtherInvestments.tsx
+++ b/src/components/income/OtherInvestments.tsx
@@ -88,6 +88,7 @@ export const OtherInvestments = (): ReactElement => {
   const methods = useForm<AssetUserInput>({ defaultValues })
   const { handleSubmit, watch } = methods
   const positionType = watch('positionType')
+  const openDate = watch('openDate')
   const closeDate = watch('closeDate')
   const dispatch = useDispatch()
 
@@ -122,12 +123,13 @@ export const OtherInvestments = (): ReactElement => {
           name="name"
         />
         <DatePicker
-          maxDate={new Date(2021, 12, 31)}
+          maxDate={new Date()}
           label="Date acquired"
           name="openDate"
         />
         <DatePicker
-          maxDate={new Date(2021, 12, 31)}
+          maxDate={new Date()}
+          minDate={openDate}
           label="Date sold or disposed of"
           name="closeDate"
         />


### PR DESCRIPTION
The investments entry form had a limitation that the max date was `new Date(2021, 12, 31)`. Because Javascript months are 0-indexed, this actually mapped to January 31, 2022. This also meant that investments bought or sold after this date couldn't be entered.

Fix this by having the max date be today. I think there's anyways logic to only use investments in the specified tax year for tax calculations. Also make sure that the date sold field has a date that isn't older than the date acquired field.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ustaxes/ustaxes/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

<!-- 
If this PR resolves a specific issue include "Fixes #xxx" in the PR description so the issue is linked and automatically closed on merge.

Please sign all your commits. See https://github.com/ustaxes/UsTaxes/blob/master/docs/CONTRIBUTING.md#pull-request-guidelines for information on setting this up.

-->
