### PR TITLE
fix: make combinePdfs linear to preserve page order and content

### DIFF
--- a/src/core/pdfFiller/pdfHandler.ts
+++ b/src/core/pdfFiller/pdfHandler.ts
@@ -22,18 +22,14 @@ export const downloadPDF: PDFDownloader = async (url) => {
 export const combinePdfs = async (
   pdfFiles: PDFDocument[]
 ): Promise<PDFDocument> => {
-  const [head, ...rest] = await Promise.all(
-    pdfFiles.map(async (pdf) => PDFDocument.load(await pdf.save()))
-  )
+  const mergedPdf = await PDFDocument.create()
 
-  // Make sure we combine the documents from left to right and preserve order
-  return rest.reduce(async (l, r) => {
-    const doc = await PDFDocument.load(await (await l).save())
-    return await doc.copyPages(r, r.getPageIndices()).then((pgs) => {
-      pgs.forEach((p) => doc.addPage(p))
-      return doc
-    })
-  }, Promise.resolve(head))
+  for (const pdf of pdfFiles) {
+    const copiedPages = await mergedPdf.copyPages(pdf, pdf.getPageIndices())
+    copiedPages.forEach((page) => mergedPdf.addPage(page))
+  }
+
+  return mergedPdf
 }
 
 export const getPdfs = async (


### PR DESCRIPTION
### Summary

This PR replaces the previous quadratic merge implementation in src/core/pdfFiller/pdfHandler.ts with a direct page-copy approach. The old code saved and reloaded PDFs repeatedly while combining them, which caused unnecessary work and risked order/content regressions.

### What changed

- `combinePdfs()` now creates a new `PDFDocument` and copies pages from each source PDF in sequence
- Preserves document order by iterating input PDFs in order and appending pages in page index order
- Eliminates repeated `save()` + `load()` cycles, reducing complexity from O(n^2) to O(n) for multi-document merges

### Test plan

- Installed dependencies with `npm install`
- Verified `src/tests/components/CreatePdf.test.tsx` passes
- Re-ran the same test file 10 times successfully with no failures

### Notes

This fix is focused on the merge helper; no UI changes were made.
